### PR TITLE
feat: add i18n support (English/Chinese/Russian)

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>12.0</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -87,7 +87,7 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   audio_streamer: 2e472b9f81cec5e381c4cf7667afa3055dcb45a4
   device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_blue_plus_darwin: 09444a26fb6bdef523e55b68fc1c59af5a877ea6
   flutter_pcm_player: ecac44cb13707ee54eb4e31252717e36acb29272
   flutter_sound: 52bc351d9035fede9085cbf99c296c62897ceadd

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -305,13 +305,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -342,13 +338,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -305,9 +305,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -338,9 +342,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -477,7 +485,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -492,16 +500,19 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = MRSXUT84XC;
+				DEVELOPMENT_TEAM = PR69YSN4WX;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lhht.aiAssistant;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lhht.aiAssistant1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -607,7 +618,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -658,7 +669,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -675,16 +686,19 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = MRSXUT84XC;
+				DEVELOPMENT_TEAM = PR69YSN4WX;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lhht.aiAssistant;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lhht.aiAssistant1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -698,16 +712,19 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = MRSXUT84XC;
+				DEVELOPMENT_TEAM = PR69YSN4WX;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lhht.aiAssistant;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lhht.aiAssistant1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -6,26 +6,27 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-               BuildableName = "Runner.app"
-               BlueprintName = "Runner"
-               ReferencedContainer = "container:Runner.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                BuildableName = "Runner.app"
+                BlueprintName = "Runner"
+                ReferencedContainer = "container:Runner.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -46,6 +46,27 @@
 	<string>需要使用麦克风进行语音通话</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>需要访问相册以选择照片进行分析</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,6 @@
+arb-dir: lib/l10n
+template-arb-file: app_zh.arb
+output-localization-file: app_localizations.dart
+output-class: S
+output-dir: lib/l10n
+synthetic-package: false

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,437 @@
+{
+  "@@locale": "en",
+  "settings": "Settings",
+  "@settings": {
+    "description": "Settings screen title"
+  },
+  "general": "General",
+  "@general": {
+    "description": "General settings tab"
+  },
+  "darkMode": "Dark Mode",
+  "@darkMode": {
+    "description": "Dark mode toggle"
+  },
+  "addConfig": "Add Config",
+  "@addConfig": {
+    "description": "Add configuration button"
+  },
+  "dify": "Dify",
+  "@dify": {
+    "description": "Dify tab label"
+  },
+  "minimax": "MiniMax",
+  "@minimax": {
+    "description": "MiniMax tab label"
+  },
+  "xiaozhi": "Xiaozhi",
+  "@xiaozhi": {
+    "description": "Xiaozhi tab label"
+  },
+  "cancel": "Cancel",
+  "@cancel": {
+    "description": "Cancel button"
+  },
+  "confirm": "Confirm",
+  "@confirm": {
+    "description": "Confirm button"
+  },
+  "delete": "Delete",
+  "@delete": {
+    "description": "Delete button"
+  },
+  "edit": "Edit",
+  "@edit": {
+    "description": "Edit button"
+  },
+  "save": "Save",
+  "@save": {
+    "description": "Save button"
+  },
+  "messages": "Messages",
+  "@messages": {
+    "description": "Messages tab"
+  },
+  "discover": "Discover",
+  "@discover": {
+    "description": "Discover tab"
+  },
+  "searchConversations": "Search conversations",
+  "@searchConversations": {
+    "description": "Search conversations placeholder"
+  },
+  "pinConversation": "Pin Conversation",
+  "@pinConversation": {
+    "description": "Pin conversation action"
+  },
+  "allConversations": "All Conversations",
+  "@allConversations": {
+    "description": "All conversations label"
+  },
+  "noConversations": "No Conversations",
+  "@noConversations": {
+    "description": "No conversations empty state"
+  },
+  "discovery": "Discover",
+  "@discovery": {
+    "description": "Discovery screen title"
+  },
+  "text": "Text",
+  "@text": {
+    "description": "Text message type"
+  },
+  "voice": "Voice",
+  "@voice": {
+    "description": "Voice message type"
+  },
+  "yesterday": "Yesterday",
+  "@yesterday": {
+    "description": "Yesterday label"
+  },
+  "language": "Language",
+  "@language": {
+    "description": "Language selector label"
+  },
+  "createNewConversation": "Tap + to create new conversation",
+  "@createNewConversation": {
+    "description": "Empty state instruction to create new conversation"
+  },
+  "deleted": "deleted",
+  "@deleted": {
+    "description": "Deleted confirmation suffix"
+  },
+  "undo": "Undo",
+  "@undo": {
+    "description": "Undo action"
+  },
+  "unpinConversation": "Unpin conversation",
+  "@unpinConversation": {
+    "description": "Unpin conversation action"
+  },
+  "deleteConversation": "Delete conversation",
+  "@deleteConversation": {
+    "description": "Delete conversation action"
+  },
+  "weekday1": "Mon",
+  "@weekday1": {
+    "description": "Monday"
+  },
+  "weekday2": "Tue",
+  "@weekday2": {
+    "description": "Tuesday"
+  },
+  "weekday3": "Wed",
+  "@weekday3": {
+    "description": "Wednesday"
+  },
+  "weekday4": "Thu",
+  "@weekday4": {
+    "description": "Thursday"
+  },
+  "weekday5": "Fri",
+  "@weekday5": {
+    "description": "Friday"
+  },
+  "weekday6": "Sat",
+  "@weekday6": {
+    "description": "Saturday"
+  },
+  "weekday7": "Sun",
+  "@weekday7": {
+    "description": "Sunday"
+  },
+  "practicalTools": "Practical Tools",
+  "@practicalTools": {
+    "description": "Practical tools section header"
+  },
+  "featuredRecommendations": "Featured Recommendations",
+  "@featuredRecommendations": {
+    "description": "Featured recommendations section header"
+  },
+  "readingAssistant": "Reading Assistant",
+  "@readingAssistant": {
+    "description": "Reading assistant card title"
+  },
+  "readingAssistantDesc": "Efficiently understand and summarize articles",
+  "@readingAssistantDesc": {
+    "description": "Reading assistant description"
+  },
+  "translationTool": "Translation Tool",
+  "@translationTool": {
+    "description": "Translation tool card title"
+  },
+  "translationToolDesc": "Real-time multilingual translation",
+  "@translationToolDesc": {
+    "description": "Translation tool description"
+  },
+  "voiceAssistant": "Voice Assistant",
+  "@voiceAssistant": {
+    "description": "Voice assistant card title"
+  },
+  "voiceAssistantDesc": "Intelligent voice interaction",
+  "@voiceAssistantDesc": {
+    "description": "Voice assistant description"
+  },
+  "documentParser": "Document Parser",
+  "@documentParser": {
+    "description": "Document parser card title"
+  },
+  "documentParserDesc": "Intelligent document content analysis",
+  "@documentParserDesc": {
+    "description": "Document parser description"
+  },
+  "aiWritingAssistant": "AI Writing Assistant",
+  "@aiWritingAssistant": {
+    "description": "AI writing assistant card title"
+  },
+  "aiWritingAssistantDesc": "Make your articles more professional",
+  "@aiWritingAssistantDesc": {
+    "description": "AI writing assistant description"
+  },
+  "smartReminder": "Smart Reminder",
+  "@smartReminder": {
+    "description": "Smart reminder card title"
+  },
+  "smartReminderDesc": "Do not miss important matters",
+  "@smartReminderDesc": {
+    "description": "Smart reminder description"
+  },
+  "voiceNotes": "Voice Notes",
+  "@voiceNotes": {
+    "description": "Voice notes card title"
+  },
+  "voiceNotesDesc": "Capture inspiration anytime, anywhere",
+  "@voiceNotesDesc": {
+    "description": "Voice notes description"
+  },
+  "underDevelopment": "Under Development",
+  "@underDevelopment": {
+    "description": "Under development suffix for feature cards"
+  },
+  "appearance": "Appearance",
+  "@appearance": {
+    "description": "appearance string"
+  },
+  "appearanceSettingsSubtitle": "Adjust app appearance settings",
+  "@appearanceSettingsSubtitle": {
+    "description": "appearanceSettingsSubtitle string"
+  },
+  "fillAllFields": "Please fill all fields",
+  "@fillAllFields": {
+    "description": "fillAllFields string"
+  },
+  "difyConfigAdded": "Dify config added",
+  "@difyConfigAdded": {
+    "description": "difyConfigAdded string"
+  },
+  "addNewDifyConfig": "Add new Dify API config",
+  "@addNewDifyConfig": {
+    "description": "addNewDifyConfig string"
+  },
+  "editDifyConfig": "Edit Dify config",
+  "@editDifyConfig": {
+    "description": "editDifyConfig string"
+  },
+  "apiAddress": "API Address",
+  "@apiAddress": {
+    "description": "apiAddress string"
+  },
+  "apiKey": "API Key",
+  "@apiKey": {
+    "description": "apiKey string"
+  },
+  "configName": "Config Name",
+  "@configName": {
+    "description": "configName string"
+  },
+  "inputConfigName": "Input config name",
+  "@inputConfigName": {
+    "description": "inputConfigName string"
+  },
+  "difyConfigUpdated": "Dify config updated",
+  "@difyConfigUpdated": {
+    "description": "difyConfigUpdated string"
+  },
+  "deleteDifyConfig": "Delete Dify config",
+  "@deleteDifyConfig": {
+    "description": "deleteDifyConfig string"
+  },
+  "confirmDeleteDify": "Delete this config? This action cannot be undone.",
+  "@confirmDeleteDify": {
+    "description": "confirmDeleteDify string"
+  },
+  "configDeleted": "Config deleted",
+  "@configDeleted": {
+    "description": "configDeleted string"
+  },
+  "noDifyConfig": "No Dify config, tap + to add",
+  "@noDifyConfig": {
+    "description": "noDifyConfig string"
+  },
+  "minimaxConfigAdded": "MiniMax config added",
+  "@minimaxConfigAdded": {
+    "description": "minimaxConfigAdded string"
+  },
+  "addNewMinimaxConfig": "Add new MiniMax AI config",
+  "@addNewMinimaxConfig": {
+    "description": "addNewMinimaxConfig string"
+  },
+  "editMinimaxConfig": "Edit MiniMax config",
+  "@editMinimaxConfig": {
+    "description": "editMinimaxConfig string"
+  },
+  "minimaxConfigUpdated": "MiniMax config updated",
+  "@minimaxConfigUpdated": {
+    "description": "minimaxConfigUpdated string"
+  },
+  "deleteMinimaxConfig": "Delete MiniMax config",
+  "@deleteMinimaxConfig": {
+    "description": "deleteMinimaxConfig string"
+  },
+  "confirmDeleteMinimax": "Delete this config?",
+  "@confirmDeleteMinimax": {
+    "description": "confirmDeleteMinimax string"
+  },
+  "noMinimaxConfig": "No MiniMax config, tap + to add",
+  "@noMinimaxConfig": {
+    "description": "noMinimaxConfig string"
+  },
+  "model": "Model",
+  "@model": {
+    "description": "model string"
+  },
+  "xiaozhiServiceConfig": "Xiaozhi Service Config",
+  "@xiaozhiServiceConfig": {
+    "description": "xiaozhiServiceConfig string"
+  },
+  "xiaozhiServiceConfigSubtitle": "Manage Xiaozhi voice service config",
+  "@xiaozhiServiceConfigSubtitle": {
+    "description": "xiaozhiServiceConfigSubtitle string"
+  },
+  "addXiaozhiService": "Add Xiaozhi service",
+  "@addXiaozhiService": {
+    "description": "addXiaozhiService string"
+  },
+  "addNewXiaozhiServiceConfig": "Add new Xiaozhi voice service config",
+  "@addNewXiaozhiServiceConfig": {
+    "description": "addNewXiaozhiServiceConfig string"
+  },
+  "editXiaozhiService": "Edit Xiaozhi service",
+  "@editXiaozhiService": {
+    "description": "editXiaozhiService string"
+  },
+  "modifyXiaozhiServiceConfig": "Modify Xiaozhi voice service config",
+  "@modifyXiaozhiServiceConfig": {
+    "description": "modifyXiaozhiServiceConfig string"
+  },
+  "serviceName": "Service Name",
+  "@serviceName": {
+    "description": "serviceName string"
+  },
+  "inputServiceName": "e.g. Home Xiaozhi",
+  "@inputServiceName": {
+    "description": "inputServiceName string"
+  },
+  "websocketAddress": "WebSocket Address",
+  "@websocketAddress": {
+    "description": "websocketAddress string"
+  },
+  "inputWebsocketAddress": "e.g. wss://example.com",
+  "@inputWebsocketAddress": {
+    "description": "inputWebsocketAddress string"
+  },
+  "macAddress": "MAC Address",
+  "@macAddress": {
+    "description": "macAddress string"
+  },
+  "macAddressOptional": "MAC Address (optional)",
+  "@macAddressOptional": {
+    "description": "macAddressOptional string"
+  },
+  "autoGenerate": "Leave empty to auto-generate",
+  "@autoGenerate": {
+    "description": "autoGenerate string"
+  },
+  "autoGenerateDesc": "Auto-generated from device ID if empty",
+  "@autoGenerateDesc": {
+    "description": "autoGenerateDesc string"
+  },
+  "token": "Token",
+  "@token": {
+    "description": "token string"
+  },
+  "enabledByDefault": "Enabled by default",
+  "@enabledByDefault": {
+    "description": "enabledByDefault string"
+  },
+  "fillRequiredFields": "Please fill all required fields",
+  "@fillRequiredFields": {
+    "description": "fillRequiredFields string"
+  },
+  "xiaozhiServiceAdded": "Xiaozhi service added",
+  "@xiaozhiServiceAdded": {
+    "description": "xiaozhiServiceAdded string"
+  },
+  "xiaozhiServiceUpdated": "Xiaozhi service updated",
+  "@xiaozhiServiceUpdated": {
+    "description": "xiaozhiServiceUpdated string"
+  },
+  "deleteXiaozhiService": "Delete Xiaozhi service",
+  "@deleteXiaozhiService": {
+    "description": "deleteXiaozhiService string"
+  },
+  "confirmDeleteXiaozhi": "Delete this service?",
+  "@confirmDeleteXiaozhi": {
+    "description": "confirmDeleteXiaozhi string"
+  },
+  "xiaozhiServiceDeleted": "Xiaozhi service deleted",
+  "@xiaozhiServiceDeleted": {
+    "description": "xiaozhiServiceDeleted string"
+  },
+  "addService": "Add service",
+  "@addService": {
+    "description": "addService string"
+  },
+  "noXiaozhiService": "No Xiaozhi service, tap + to add",
+  "@noXiaozhiService": {
+    "description": "noXiaozhiService string"
+  },
+  "unconfigured": "Not configured",
+  "@unconfigured": {
+    "description": "unconfigured string"
+  },
+  "difyApiConfig": "Dify API Config",
+  "@difyApiConfig": {
+    "description": "difyApiConfig string"
+  },
+  "difyApiConfigSubtitle": "Configure and manage multiple Dify API services",
+  "@difyApiConfigSubtitle": {
+    "description": "difyApiConfigSubtitle string"
+  },
+  "minimaxAiConfig": "MiniMax AI Config",
+  "@minimaxAiConfig": {
+    "description": "minimaxAiConfig string"
+  },
+  "minimaxAiConfigSubtitle": "Configure and manage MiniMax API services",
+  "@minimaxAiConfigSubtitle": {
+    "description": "minimaxAiConfigSubtitle string"
+  },
+  "add": "Add",
+  "@add": {
+    "description": "Add button"
+  },
+  "addDifyConfig": "Add Dify Config",
+  "@addDifyConfig": {
+    "description": "addDifyConfig string"
+  },
+  "addMinimaxConfig": "Add MiniMax Config",
+  "@addMinimaxConfig": {
+    "description": "addMinimaxConfig string"
+  },
+  "enterApiKey": "Enter API Key",
+  "@enterApiKey": {"description": "Hint text for API Key input field"},
+  "enterMinimaxApiKey": "Enter MiniMax API Key",
+  "@enterMinimaxApiKey": {"description": "Hint text for MiniMax API Key input"},
+  "wsExample": "e.g. wss://example.com",
+  "@wsExample": {"description": "Example WebSocket address hint"}
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,796 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_ru.dart';
+import 'app_localizations_zh.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of S
+/// returned by `S.of(context)`.
+///
+/// Applications need to include `S.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: S.localizationsDelegates,
+///   supportedLocales: S.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the S.supportedLocales
+/// property.
+abstract class S {
+  S(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static S? of(BuildContext context) {
+    return Localizations.of<S>(context, S);
+  }
+
+  static const LocalizationsDelegate<S> delegate = _SDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ru'),
+    Locale('zh'),
+  ];
+
+  /// Settings screen title
+  ///
+  /// In zh, this message translates to:
+  /// **'设置'**
+  String get settings;
+
+  /// General settings tab
+  ///
+  /// In zh, this message translates to:
+  /// **'通用'**
+  String get general;
+
+  /// Dark mode toggle
+  ///
+  /// In zh, this message translates to:
+  /// **'深色模式'**
+  String get darkMode;
+
+  /// Add configuration button
+  ///
+  /// In zh, this message translates to:
+  /// **'添加配置'**
+  String get addConfig;
+
+  /// Dify tab label
+  ///
+  /// In zh, this message translates to:
+  /// **'Dify'**
+  String get dify;
+
+  /// MiniMax tab label
+  ///
+  /// In zh, this message translates to:
+  /// **'MiniMax'**
+  String get minimax;
+
+  /// Xiaozhi tab label
+  ///
+  /// In zh, this message translates to:
+  /// **'小智'**
+  String get xiaozhi;
+
+  /// Cancel button
+  ///
+  /// In zh, this message translates to:
+  /// **'取消'**
+  String get cancel;
+
+  /// Confirm button
+  ///
+  /// In zh, this message translates to:
+  /// **'确认'**
+  String get confirm;
+
+  /// Delete button
+  ///
+  /// In zh, this message translates to:
+  /// **'删除'**
+  String get delete;
+
+  /// Edit button
+  ///
+  /// In zh, this message translates to:
+  /// **'编辑'**
+  String get edit;
+
+  /// Save button
+  ///
+  /// In zh, this message translates to:
+  /// **'保存'**
+  String get save;
+
+  /// Messages tab
+  ///
+  /// In zh, this message translates to:
+  /// **'消息'**
+  String get messages;
+
+  /// Discover tab
+  ///
+  /// In zh, this message translates to:
+  /// **'发现'**
+  String get discover;
+
+  /// Search conversations placeholder
+  ///
+  /// In zh, this message translates to:
+  /// **'搜索对话'**
+  String get searchConversations;
+
+  /// Pin conversation action
+  ///
+  /// In zh, this message translates to:
+  /// **'置顶对话'**
+  String get pinConversation;
+
+  /// All conversations label
+  ///
+  /// In zh, this message translates to:
+  /// **'全部对话'**
+  String get allConversations;
+
+  /// No conversations empty state
+  ///
+  /// In zh, this message translates to:
+  /// **'没有对话'**
+  String get noConversations;
+
+  /// Discovery screen title
+  ///
+  /// In zh, this message translates to:
+  /// **'发现'**
+  String get discovery;
+
+  /// Text message type
+  ///
+  /// In zh, this message translates to:
+  /// **'文本'**
+  String get text;
+
+  /// Voice message type
+  ///
+  /// In zh, this message translates to:
+  /// **'语音'**
+  String get voice;
+
+  /// Yesterday label
+  ///
+  /// In zh, this message translates to:
+  /// **'昨天'**
+  String get yesterday;
+
+  /// Language selector label
+  ///
+  /// In zh, this message translates to:
+  /// **'语言'**
+  String get language;
+
+  /// Empty state instruction to create new conversation
+  ///
+  /// In zh, this message translates to:
+  /// **'点击 + 创建新对话'**
+  String get createNewConversation;
+
+  /// Deleted confirmation suffix
+  ///
+  /// In zh, this message translates to:
+  /// **'已删除'**
+  String get deleted;
+
+  /// Undo action
+  ///
+  /// In zh, this message translates to:
+  /// **'撤销'**
+  String get undo;
+
+  /// Unpin conversation action
+  ///
+  /// In zh, this message translates to:
+  /// **'取消置顶'**
+  String get unpinConversation;
+
+  /// Delete conversation action
+  ///
+  /// In zh, this message translates to:
+  /// **'删除对话'**
+  String get deleteConversation;
+
+  /// Monday
+  ///
+  /// In zh, this message translates to:
+  /// **'一'**
+  String get weekday1;
+
+  /// Tuesday
+  ///
+  /// In zh, this message translates to:
+  /// **'二'**
+  String get weekday2;
+
+  /// Wednesday
+  ///
+  /// In zh, this message translates to:
+  /// **'三'**
+  String get weekday3;
+
+  /// Thursday
+  ///
+  /// In zh, this message translates to:
+  /// **'四'**
+  String get weekday4;
+
+  /// Friday
+  ///
+  /// In zh, this message translates to:
+  /// **'五'**
+  String get weekday5;
+
+  /// Saturday
+  ///
+  /// In zh, this message translates to:
+  /// **'六'**
+  String get weekday6;
+
+  /// Sunday
+  ///
+  /// In zh, this message translates to:
+  /// **'日'**
+  String get weekday7;
+
+  /// Practical tools section header
+  ///
+  /// In zh, this message translates to:
+  /// **'实用工具'**
+  String get practicalTools;
+
+  /// Featured recommendations section header
+  ///
+  /// In zh, this message translates to:
+  /// **'精选推荐'**
+  String get featuredRecommendations;
+
+  /// Reading assistant card title
+  ///
+  /// In zh, this message translates to:
+  /// **'阅读助手'**
+  String get readingAssistant;
+
+  /// Reading assistant description
+  ///
+  /// In zh, this message translates to:
+  /// **'高效理解和总结文章'**
+  String get readingAssistantDesc;
+
+  /// Translation tool card title
+  ///
+  /// In zh, this message translates to:
+  /// **'翻译工具'**
+  String get translationTool;
+
+  /// Translation tool description
+  ///
+  /// In zh, this message translates to:
+  /// **'多语言实时翻译'**
+  String get translationToolDesc;
+
+  /// Voice assistant card title
+  ///
+  /// In zh, this message translates to:
+  /// **'语音助手'**
+  String get voiceAssistant;
+
+  /// Voice assistant description
+  ///
+  /// In zh, this message translates to:
+  /// **'智能语音交互'**
+  String get voiceAssistantDesc;
+
+  /// Document parser card title
+  ///
+  /// In zh, this message translates to:
+  /// **'文档解析'**
+  String get documentParser;
+
+  /// Document parser description
+  ///
+  /// In zh, this message translates to:
+  /// **'智能分析文档内容'**
+  String get documentParserDesc;
+
+  /// AI writing assistant card title
+  ///
+  /// In zh, this message translates to:
+  /// **'AI写作助手'**
+  String get aiWritingAssistant;
+
+  /// AI writing assistant description
+  ///
+  /// In zh, this message translates to:
+  /// **'让你的文章更专业'**
+  String get aiWritingAssistantDesc;
+
+  /// Smart reminder card title
+  ///
+  /// In zh, this message translates to:
+  /// **'智能提醒'**
+  String get smartReminder;
+
+  /// Smart reminder description
+  ///
+  /// In zh, this message translates to:
+  /// **'不错过重要事项'**
+  String get smartReminderDesc;
+
+  /// Voice notes card title
+  ///
+  /// In zh, this message translates to:
+  /// **'语音笔记'**
+  String get voiceNotes;
+
+  /// Voice notes description
+  ///
+  /// In zh, this message translates to:
+  /// **'随时随地记录灵感'**
+  String get voiceNotesDesc;
+
+  /// Under development suffix for feature cards
+  ///
+  /// In zh, this message translates to:
+  /// **'功能开发中'**
+  String get underDevelopment;
+
+  /// appearance string
+  ///
+  /// In zh, this message translates to:
+  /// **'外观'**
+  String get appearance;
+
+  /// appearanceSettingsSubtitle string
+  ///
+  /// In zh, this message translates to:
+  /// **'调整应用的外观设置'**
+  String get appearanceSettingsSubtitle;
+
+  /// fillAllFields string
+  ///
+  /// In zh, this message translates to:
+  /// **'请填写所有字段'**
+  String get fillAllFields;
+
+  /// difyConfigAdded string
+  ///
+  /// In zh, this message translates to:
+  /// **'已添加Dify配置'**
+  String get difyConfigAdded;
+
+  /// addNewDifyConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'添加新的Dify API配置'**
+  String get addNewDifyConfig;
+
+  /// editDifyConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'编辑Dify配置'**
+  String get editDifyConfig;
+
+  /// apiAddress string
+  ///
+  /// In zh, this message translates to:
+  /// **'API地址'**
+  String get apiAddress;
+
+  /// apiKey string
+  ///
+  /// In zh, this message translates to:
+  /// **'API密钥'**
+  String get apiKey;
+
+  /// configName string
+  ///
+  /// In zh, this message translates to:
+  /// **'配置名称'**
+  String get configName;
+
+  /// inputConfigName string
+  ///
+  /// In zh, this message translates to:
+  /// **'输入配置名称'**
+  String get inputConfigName;
+
+  /// difyConfigUpdated string
+  ///
+  /// In zh, this message translates to:
+  /// **'已更新Dify配置'**
+  String get difyConfigUpdated;
+
+  /// deleteDifyConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'删除Dify配置'**
+  String get deleteDifyConfig;
+
+  /// confirmDeleteDify string
+  ///
+  /// In zh, this message translates to:
+  /// **'确定要删除配置吗？这个操作不可撤销。'**
+  String get confirmDeleteDify;
+
+  /// configDeleted string
+  ///
+  /// In zh, this message translates to:
+  /// **'已删除配置'**
+  String get configDeleted;
+
+  /// noDifyConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'暂无Dify配置，点击右上角添加'**
+  String get noDifyConfig;
+
+  /// minimaxConfigAdded string
+  ///
+  /// In zh, this message translates to:
+  /// **'已添加MiniMax配置'**
+  String get minimaxConfigAdded;
+
+  /// addNewMinimaxConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'添加新的MiniMax AI配置'**
+  String get addNewMinimaxConfig;
+
+  /// editMinimaxConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'编辑MiniMax配置'**
+  String get editMinimaxConfig;
+
+  /// minimaxConfigUpdated string
+  ///
+  /// In zh, this message translates to:
+  /// **'已更新MiniMax配置'**
+  String get minimaxConfigUpdated;
+
+  /// deleteMinimaxConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'删除MiniMax配置'**
+  String get deleteMinimaxConfig;
+
+  /// confirmDeleteMinimax string
+  ///
+  /// In zh, this message translates to:
+  /// **'确定要删除配置吗？'**
+  String get confirmDeleteMinimax;
+
+  /// noMinimaxConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'暂无MiniMax配置，点击右上角添加'**
+  String get noMinimaxConfig;
+
+  /// model string
+  ///
+  /// In zh, this message translates to:
+  /// **'模型'**
+  String get model;
+
+  /// xiaozhiServiceConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'小智服务配置'**
+  String get xiaozhiServiceConfig;
+
+  /// xiaozhiServiceConfigSubtitle string
+  ///
+  /// In zh, this message translates to:
+  /// **'管理小智语音服务配置'**
+  String get xiaozhiServiceConfigSubtitle;
+
+  /// addXiaozhiService string
+  ///
+  /// In zh, this message translates to:
+  /// **'添加小智服务'**
+  String get addXiaozhiService;
+
+  /// addNewXiaozhiServiceConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'添加新的小智语音服务配置'**
+  String get addNewXiaozhiServiceConfig;
+
+  /// editXiaozhiService string
+  ///
+  /// In zh, this message translates to:
+  /// **'编辑小智服务'**
+  String get editXiaozhiService;
+
+  /// modifyXiaozhiServiceConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'修改小智语音服务配置'**
+  String get modifyXiaozhiServiceConfig;
+
+  /// serviceName string
+  ///
+  /// In zh, this message translates to:
+  /// **'服务名称'**
+  String get serviceName;
+
+  /// inputServiceName string
+  ///
+  /// In zh, this message translates to:
+  /// **'例如：家庭小智'**
+  String get inputServiceName;
+
+  /// websocketAddress string
+  ///
+  /// In zh, this message translates to:
+  /// **'WebSocket地址'**
+  String get websocketAddress;
+
+  /// inputWebsocketAddress string
+  ///
+  /// In zh, this message translates to:
+  /// **'例如：wss://example.com'**
+  String get inputWebsocketAddress;
+
+  /// macAddress string
+  ///
+  /// In zh, this message translates to:
+  /// **'MAC地址'**
+  String get macAddress;
+
+  /// macAddressOptional string
+  ///
+  /// In zh, this message translates to:
+  /// **'MAC地址 (可选)'**
+  String get macAddressOptional;
+
+  /// autoGenerate string
+  ///
+  /// In zh, this message translates to:
+  /// **'留空将自动生成'**
+  String get autoGenerate;
+
+  /// autoGenerateDesc string
+  ///
+  /// In zh, this message translates to:
+  /// **'留空将根据设备ID自动生成'**
+  String get autoGenerateDesc;
+
+  /// token string
+  ///
+  /// In zh, this message translates to:
+  /// **'Token'**
+  String get token;
+
+  /// enabledByDefault string
+  ///
+  /// In zh, this message translates to:
+  /// **'默认开启'**
+  String get enabledByDefault;
+
+  /// fillRequiredFields string
+  ///
+  /// In zh, this message translates to:
+  /// **'请填写所有必填字段'**
+  String get fillRequiredFields;
+
+  /// xiaozhiServiceAdded string
+  ///
+  /// In zh, this message translates to:
+  /// **'小智服务已添加'**
+  String get xiaozhiServiceAdded;
+
+  /// xiaozhiServiceUpdated string
+  ///
+  /// In zh, this message translates to:
+  /// **'小智服务已更新'**
+  String get xiaozhiServiceUpdated;
+
+  /// deleteXiaozhiService string
+  ///
+  /// In zh, this message translates to:
+  /// **'删除小智服务'**
+  String get deleteXiaozhiService;
+
+  /// confirmDeleteXiaozhi string
+  ///
+  /// In zh, this message translates to:
+  /// **'确定要删除服务吗？'**
+  String get confirmDeleteXiaozhi;
+
+  /// xiaozhiServiceDeleted string
+  ///
+  /// In zh, this message translates to:
+  /// **'小智服务已删除'**
+  String get xiaozhiServiceDeleted;
+
+  /// addService string
+  ///
+  /// In zh, this message translates to:
+  /// **'添加服务'**
+  String get addService;
+
+  /// noXiaozhiService string
+  ///
+  /// In zh, this message translates to:
+  /// **'暂无小智服务，点击右上角添加'**
+  String get noXiaozhiService;
+
+  /// unconfigured string
+  ///
+  /// In zh, this message translates to:
+  /// **'未设置'**
+  String get unconfigured;
+
+  /// difyApiConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'Dify API配置'**
+  String get difyApiConfig;
+
+  /// difyApiConfigSubtitle string
+  ///
+  /// In zh, this message translates to:
+  /// **'配置并管理多个Dify API服务'**
+  String get difyApiConfigSubtitle;
+
+  /// minimaxAiConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'MiniMax AI配置'**
+  String get minimaxAiConfig;
+
+  /// minimaxAiConfigSubtitle string
+  ///
+  /// In zh, this message translates to:
+  /// **'配置并管理MiniMax API服务'**
+  String get minimaxAiConfigSubtitle;
+
+  /// Add button
+  ///
+  /// In zh, this message translates to:
+  /// **'添加'**
+  String get add;
+
+  /// addDifyConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'添加Dify配置'**
+  String get addDifyConfig;
+
+  /// addMinimaxConfig string
+  ///
+  /// In zh, this message translates to:
+  /// **'添加MiniMax配置'**
+  String get addMinimaxConfig;
+
+  /// Hint text for API Key input field
+  ///
+  /// In zh, this message translates to:
+  /// **'输入API Key'**
+  String get enterApiKey;
+
+  /// Hint text for MiniMax API Key input
+  ///
+  /// In zh, this message translates to:
+  /// **'输入MiniMax API Key'**
+  String get enterMinimaxApiKey;
+
+  /// Example WebSocket address hint
+  ///
+  /// In zh, this message translates to:
+  /// **'例如：wss://example.com'**
+  String get wsExample;
+}
+
+class _SDelegate extends LocalizationsDelegate<S> {
+  const _SDelegate();
+
+  @override
+  Future<S> load(Locale locale) {
+    return SynchronousFuture<S>(lookupS(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en', 'ru', 'zh'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_SDelegate old) => false;
+}
+
+S lookupS(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return SEn();
+    case 'ru':
+      return SRu();
+    case 'zh':
+      return SZh();
+  }
+
+  throw FlutterError(
+    'S.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
+}

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,347 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class SEn extends S {
+  SEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get settings => 'Settings';
+
+  @override
+  String get general => 'General';
+
+  @override
+  String get darkMode => 'Dark Mode';
+
+  @override
+  String get addConfig => 'Add Config';
+
+  @override
+  String get dify => 'Dify';
+
+  @override
+  String get minimax => 'MiniMax';
+
+  @override
+  String get xiaozhi => 'Xiaozhi';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get confirm => 'Confirm';
+
+  @override
+  String get delete => 'Delete';
+
+  @override
+  String get edit => 'Edit';
+
+  @override
+  String get save => 'Save';
+
+  @override
+  String get messages => 'Messages';
+
+  @override
+  String get discover => 'Discover';
+
+  @override
+  String get searchConversations => 'Search conversations';
+
+  @override
+  String get pinConversation => 'Pin Conversation';
+
+  @override
+  String get allConversations => 'All Conversations';
+
+  @override
+  String get noConversations => 'No Conversations';
+
+  @override
+  String get discovery => 'Discover';
+
+  @override
+  String get text => 'Text';
+
+  @override
+  String get voice => 'Voice';
+
+  @override
+  String get yesterday => 'Yesterday';
+
+  @override
+  String get language => 'Language';
+
+  @override
+  String get createNewConversation => 'Tap + to create new conversation';
+
+  @override
+  String get deleted => 'deleted';
+
+  @override
+  String get undo => 'Undo';
+
+  @override
+  String get unpinConversation => 'Unpin conversation';
+
+  @override
+  String get deleteConversation => 'Delete conversation';
+
+  @override
+  String get weekday1 => 'Mon';
+
+  @override
+  String get weekday2 => 'Tue';
+
+  @override
+  String get weekday3 => 'Wed';
+
+  @override
+  String get weekday4 => 'Thu';
+
+  @override
+  String get weekday5 => 'Fri';
+
+  @override
+  String get weekday6 => 'Sat';
+
+  @override
+  String get weekday7 => 'Sun';
+
+  @override
+  String get practicalTools => 'Practical Tools';
+
+  @override
+  String get featuredRecommendations => 'Featured Recommendations';
+
+  @override
+  String get readingAssistant => 'Reading Assistant';
+
+  @override
+  String get readingAssistantDesc =>
+      'Efficiently understand and summarize articles';
+
+  @override
+  String get translationTool => 'Translation Tool';
+
+  @override
+  String get translationToolDesc => 'Real-time multilingual translation';
+
+  @override
+  String get voiceAssistant => 'Voice Assistant';
+
+  @override
+  String get voiceAssistantDesc => 'Intelligent voice interaction';
+
+  @override
+  String get documentParser => 'Document Parser';
+
+  @override
+  String get documentParserDesc => 'Intelligent document content analysis';
+
+  @override
+  String get aiWritingAssistant => 'AI Writing Assistant';
+
+  @override
+  String get aiWritingAssistantDesc => 'Make your articles more professional';
+
+  @override
+  String get smartReminder => 'Smart Reminder';
+
+  @override
+  String get smartReminderDesc => 'Do not miss important matters';
+
+  @override
+  String get voiceNotes => 'Voice Notes';
+
+  @override
+  String get voiceNotesDesc => 'Capture inspiration anytime, anywhere';
+
+  @override
+  String get underDevelopment => 'Under Development';
+
+  @override
+  String get appearance => 'Appearance';
+
+  @override
+  String get appearanceSettingsSubtitle => 'Adjust app appearance settings';
+
+  @override
+  String get fillAllFields => 'Please fill all fields';
+
+  @override
+  String get difyConfigAdded => 'Dify config added';
+
+  @override
+  String get addNewDifyConfig => 'Add new Dify API config';
+
+  @override
+  String get editDifyConfig => 'Edit Dify config';
+
+  @override
+  String get apiAddress => 'API Address';
+
+  @override
+  String get apiKey => 'API Key';
+
+  @override
+  String get configName => 'Config Name';
+
+  @override
+  String get inputConfigName => 'Input config name';
+
+  @override
+  String get difyConfigUpdated => 'Dify config updated';
+
+  @override
+  String get deleteDifyConfig => 'Delete Dify config';
+
+  @override
+  String get confirmDeleteDify =>
+      'Delete this config? This action cannot be undone.';
+
+  @override
+  String get configDeleted => 'Config deleted';
+
+  @override
+  String get noDifyConfig => 'No Dify config, tap + to add';
+
+  @override
+  String get minimaxConfigAdded => 'MiniMax config added';
+
+  @override
+  String get addNewMinimaxConfig => 'Add new MiniMax AI config';
+
+  @override
+  String get editMinimaxConfig => 'Edit MiniMax config';
+
+  @override
+  String get minimaxConfigUpdated => 'MiniMax config updated';
+
+  @override
+  String get deleteMinimaxConfig => 'Delete MiniMax config';
+
+  @override
+  String get confirmDeleteMinimax => 'Delete this config?';
+
+  @override
+  String get noMinimaxConfig => 'No MiniMax config, tap + to add';
+
+  @override
+  String get model => 'Model';
+
+  @override
+  String get xiaozhiServiceConfig => 'Xiaozhi Service Config';
+
+  @override
+  String get xiaozhiServiceConfigSubtitle =>
+      'Manage Xiaozhi voice service config';
+
+  @override
+  String get addXiaozhiService => 'Add Xiaozhi service';
+
+  @override
+  String get addNewXiaozhiServiceConfig =>
+      'Add new Xiaozhi voice service config';
+
+  @override
+  String get editXiaozhiService => 'Edit Xiaozhi service';
+
+  @override
+  String get modifyXiaozhiServiceConfig =>
+      'Modify Xiaozhi voice service config';
+
+  @override
+  String get serviceName => 'Service Name';
+
+  @override
+  String get inputServiceName => 'e.g. Home Xiaozhi';
+
+  @override
+  String get websocketAddress => 'WebSocket Address';
+
+  @override
+  String get inputWebsocketAddress => 'e.g. wss://example.com';
+
+  @override
+  String get macAddress => 'MAC Address';
+
+  @override
+  String get macAddressOptional => 'MAC Address (optional)';
+
+  @override
+  String get autoGenerate => 'Leave empty to auto-generate';
+
+  @override
+  String get autoGenerateDesc => 'Auto-generated from device ID if empty';
+
+  @override
+  String get token => 'Token';
+
+  @override
+  String get enabledByDefault => 'Enabled by default';
+
+  @override
+  String get fillRequiredFields => 'Please fill all required fields';
+
+  @override
+  String get xiaozhiServiceAdded => 'Xiaozhi service added';
+
+  @override
+  String get xiaozhiServiceUpdated => 'Xiaozhi service updated';
+
+  @override
+  String get deleteXiaozhiService => 'Delete Xiaozhi service';
+
+  @override
+  String get confirmDeleteXiaozhi => 'Delete this service?';
+
+  @override
+  String get xiaozhiServiceDeleted => 'Xiaozhi service deleted';
+
+  @override
+  String get addService => 'Add service';
+
+  @override
+  String get noXiaozhiService => 'No Xiaozhi service, tap + to add';
+
+  @override
+  String get unconfigured => 'Not configured';
+
+  @override
+  String get difyApiConfig => 'Dify API Config';
+
+  @override
+  String get difyApiConfigSubtitle =>
+      'Configure and manage multiple Dify API services';
+
+  @override
+  String get minimaxAiConfig => 'MiniMax AI Config';
+
+  @override
+  String get minimaxAiConfigSubtitle =>
+      'Configure and manage MiniMax API services';
+
+  @override
+  String get add => 'Add';
+
+  @override
+  String get addDifyConfig => 'Add Dify Config';
+
+  @override
+  String get addMinimaxConfig => 'Add MiniMax Config';
+
+  @override
+  String get enterApiKey => 'Enter API Key';
+
+  @override
+  String get enterMinimaxApiKey => 'Enter MiniMax API Key';
+
+  @override
+  String get wsExample => 'e.g. wss://example.com';
+}

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1,0 +1,349 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Russian (`ru`).
+class SRu extends S {
+  SRu([String locale = 'ru']) : super(locale);
+
+  @override
+  String get settings => 'Настройки';
+
+  @override
+  String get general => 'Общие';
+
+  @override
+  String get darkMode => 'Тёмный режим';
+
+  @override
+  String get addConfig => 'Добавить конфиг';
+
+  @override
+  String get dify => 'Dify';
+
+  @override
+  String get minimax => 'MiniMax';
+
+  @override
+  String get xiaozhi => 'Xiaozhi';
+
+  @override
+  String get cancel => 'Отмена';
+
+  @override
+  String get confirm => 'Подтвердить';
+
+  @override
+  String get delete => 'Удалить';
+
+  @override
+  String get edit => 'Редактировать';
+
+  @override
+  String get save => 'Сохранить';
+
+  @override
+  String get messages => 'Сообщения';
+
+  @override
+  String get discover => 'Обзор';
+
+  @override
+  String get searchConversations => 'Поиск диалогов';
+
+  @override
+  String get pinConversation => 'Закрепить диалог';
+
+  @override
+  String get allConversations => 'Все диалоги';
+
+  @override
+  String get noConversations => 'Нет диалогов';
+
+  @override
+  String get discovery => 'Обзор';
+
+  @override
+  String get text => 'Текст';
+
+  @override
+  String get voice => 'Голос';
+
+  @override
+  String get yesterday => 'Вчера';
+
+  @override
+  String get language => 'Язык';
+
+  @override
+  String get createNewConversation => 'Нажмите + чтобы создать новый диалог';
+
+  @override
+  String get deleted => 'удалено';
+
+  @override
+  String get undo => 'Отменить';
+
+  @override
+  String get unpinConversation => 'Открепить диалог';
+
+  @override
+  String get deleteConversation => 'Удалить диалог';
+
+  @override
+  String get weekday1 => 'Пн';
+
+  @override
+  String get weekday2 => 'Вт';
+
+  @override
+  String get weekday3 => 'Ср';
+
+  @override
+  String get weekday4 => 'Чт';
+
+  @override
+  String get weekday5 => 'Пт';
+
+  @override
+  String get weekday6 => 'Сб';
+
+  @override
+  String get weekday7 => 'Вс';
+
+  @override
+  String get practicalTools => 'Практические инструменты';
+
+  @override
+  String get featuredRecommendations => 'Рекомендуемые';
+
+  @override
+  String get readingAssistant => 'Ассистент чтения';
+
+  @override
+  String get readingAssistantDesc => 'Эффективное понимание и обобщение статей';
+
+  @override
+  String get translationTool => 'Инструмент перевода';
+
+  @override
+  String get translationToolDesc => 'Мгновенный многоязычный перевод';
+
+  @override
+  String get voiceAssistant => 'Голосовой ассистент';
+
+  @override
+  String get voiceAssistantDesc => 'Интеллектуальное голосовое взаимодействие';
+
+  @override
+  String get documentParser => 'Анализатор документов';
+
+  @override
+  String get documentParserDesc =>
+      'Интеллектуальный анализ содержимого документов';
+
+  @override
+  String get aiWritingAssistant => 'AI-ассистент написания';
+
+  @override
+  String get aiWritingAssistantDesc =>
+      'Сделайте ваши статьи более профессиональными';
+
+  @override
+  String get smartReminder => 'Умный напоминатель';
+
+  @override
+  String get smartReminderDesc => 'Не пропустите важные дела';
+
+  @override
+  String get voiceNotes => 'Голосовые заметки';
+
+  @override
+  String get voiceNotesDesc => 'Записывайте идеи в любой момент';
+
+  @override
+  String get underDevelopment => 'В разработке';
+
+  @override
+  String get appearance => 'Внешний вид';
+
+  @override
+  String get appearanceSettingsSubtitle => 'Настройка внешнего вида приложения';
+
+  @override
+  String get fillAllFields => 'Пожалуйста, заполните все поля';
+
+  @override
+  String get difyConfigAdded => 'Конфиг Dify добавлен';
+
+  @override
+  String get addNewDifyConfig => 'Добавить новый конфиг Dify API';
+
+  @override
+  String get editDifyConfig => 'Редактировать конфиг Dify';
+
+  @override
+  String get apiAddress => 'Адрес API';
+
+  @override
+  String get apiKey => 'Ключ API';
+
+  @override
+  String get configName => 'Название конфига';
+
+  @override
+  String get inputConfigName => 'Введите название конфига';
+
+  @override
+  String get difyConfigUpdated => 'Конфиг Dify обновлён';
+
+  @override
+  String get deleteDifyConfig => 'Удалить конфиг Dify';
+
+  @override
+  String get confirmDeleteDify =>
+      'Удалить этот конфиг? Это действие нельзя отменить.';
+
+  @override
+  String get configDeleted => 'Конфиг удалён';
+
+  @override
+  String get noDifyConfig => 'Нет конфига Dify, нажмите +';
+
+  @override
+  String get minimaxConfigAdded => 'Конфиг MiniMax добавлен';
+
+  @override
+  String get addNewMinimaxConfig => 'Добавить новый конфиг MiniMax AI';
+
+  @override
+  String get editMinimaxConfig => 'Редактировать конфиг MiniMax';
+
+  @override
+  String get minimaxConfigUpdated => 'Конфиг MiniMax обновлён';
+
+  @override
+  String get deleteMinimaxConfig => 'Удалить конфиг MiniMax';
+
+  @override
+  String get confirmDeleteMinimax => 'Удалить этот конфиг?';
+
+  @override
+  String get noMinimaxConfig => 'Нет конфига MiniMax, нажмите +';
+
+  @override
+  String get model => 'Модель';
+
+  @override
+  String get xiaozhiServiceConfig => 'Конфиг сервиса Xiaozhi';
+
+  @override
+  String get xiaozhiServiceConfigSubtitle =>
+      'Управление конфигом голосового сервиса Xiaozhi';
+
+  @override
+  String get addXiaozhiService => 'Добавить сервис Xiaozhi';
+
+  @override
+  String get addNewXiaozhiServiceConfig =>
+      'Добавить новый конфиг голосового сервиса Xiaozhi';
+
+  @override
+  String get editXiaozhiService => 'Редактировать сервис Xiaozhi';
+
+  @override
+  String get modifyXiaozhiServiceConfig =>
+      'Изменить конфиг голосового сервиса Xiaozhi';
+
+  @override
+  String get serviceName => 'Название сервиса';
+
+  @override
+  String get inputServiceName => 'напр. Домашний Xiaozhi';
+
+  @override
+  String get websocketAddress => 'WebSocket адрес';
+
+  @override
+  String get inputWebsocketAddress => 'напр. wss://example.com';
+
+  @override
+  String get macAddress => 'MAC адрес';
+
+  @override
+  String get macAddressOptional => 'MAC адрес (опц.)';
+
+  @override
+  String get autoGenerate => 'Оставьте пустым для автогенерации';
+
+  @override
+  String get autoGenerateDesc => 'Автогенерация из ID устройства';
+
+  @override
+  String get token => 'Токен';
+
+  @override
+  String get enabledByDefault => 'Включено по умолчанию';
+
+  @override
+  String get fillRequiredFields =>
+      'Пожалуйста, заполните все обязательные поля';
+
+  @override
+  String get xiaozhiServiceAdded => 'Сервис Xiaozhi добавлен';
+
+  @override
+  String get xiaozhiServiceUpdated => 'Сервис Xiaozhi обновлён';
+
+  @override
+  String get deleteXiaozhiService => 'Удалить сервис Xiaozhi';
+
+  @override
+  String get confirmDeleteXiaozhi => 'Удалить этот сервис?';
+
+  @override
+  String get xiaozhiServiceDeleted => 'Сервис Xiaozhi удалён';
+
+  @override
+  String get addService => 'Добавить сервис';
+
+  @override
+  String get noXiaozhiService => 'Нет сервиса Xiaozhi, нажмите +';
+
+  @override
+  String get unconfigured => 'Не настроено';
+
+  @override
+  String get difyApiConfig => 'Конфиг Dify API';
+
+  @override
+  String get difyApiConfigSubtitle =>
+      'Настройка и управление несколькими сервисами Dify API';
+
+  @override
+  String get minimaxAiConfig => 'Конфиг MiniMax AI';
+
+  @override
+  String get minimaxAiConfigSubtitle =>
+      'Настройка и управление сервисами MiniMax API';
+
+  @override
+  String get add => 'Добавить';
+
+  @override
+  String get addDifyConfig => 'Добавить конфиг Dify';
+
+  @override
+  String get addMinimaxConfig => 'Добавить конфиг MiniMax';
+
+  @override
+  String get enterApiKey => 'Введите API-ключ';
+
+  @override
+  String get enterMinimaxApiKey => 'Введите API-ключ MiniMax';
+
+  @override
+  String get wsExample => 'например: wss://example.com';
+}

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1,0 +1,340 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Chinese (`zh`).
+class SZh extends S {
+  SZh([String locale = 'zh']) : super(locale);
+
+  @override
+  String get settings => '设置';
+
+  @override
+  String get general => '通用';
+
+  @override
+  String get darkMode => '深色模式';
+
+  @override
+  String get addConfig => '添加配置';
+
+  @override
+  String get dify => 'Dify';
+
+  @override
+  String get minimax => 'MiniMax';
+
+  @override
+  String get xiaozhi => '小智';
+
+  @override
+  String get cancel => '取消';
+
+  @override
+  String get confirm => '确认';
+
+  @override
+  String get delete => '删除';
+
+  @override
+  String get edit => '编辑';
+
+  @override
+  String get save => '保存';
+
+  @override
+  String get messages => '消息';
+
+  @override
+  String get discover => '发现';
+
+  @override
+  String get searchConversations => '搜索对话';
+
+  @override
+  String get pinConversation => '置顶对话';
+
+  @override
+  String get allConversations => '全部对话';
+
+  @override
+  String get noConversations => '没有对话';
+
+  @override
+  String get discovery => '发现';
+
+  @override
+  String get text => '文本';
+
+  @override
+  String get voice => '语音';
+
+  @override
+  String get yesterday => '昨天';
+
+  @override
+  String get language => '语言';
+
+  @override
+  String get createNewConversation => '点击 + 创建新对话';
+
+  @override
+  String get deleted => '已删除';
+
+  @override
+  String get undo => '撤销';
+
+  @override
+  String get unpinConversation => '取消置顶';
+
+  @override
+  String get deleteConversation => '删除对话';
+
+  @override
+  String get weekday1 => '一';
+
+  @override
+  String get weekday2 => '二';
+
+  @override
+  String get weekday3 => '三';
+
+  @override
+  String get weekday4 => '四';
+
+  @override
+  String get weekday5 => '五';
+
+  @override
+  String get weekday6 => '六';
+
+  @override
+  String get weekday7 => '日';
+
+  @override
+  String get practicalTools => '实用工具';
+
+  @override
+  String get featuredRecommendations => '精选推荐';
+
+  @override
+  String get readingAssistant => '阅读助手';
+
+  @override
+  String get readingAssistantDesc => '高效理解和总结文章';
+
+  @override
+  String get translationTool => '翻译工具';
+
+  @override
+  String get translationToolDesc => '多语言实时翻译';
+
+  @override
+  String get voiceAssistant => '语音助手';
+
+  @override
+  String get voiceAssistantDesc => '智能语音交互';
+
+  @override
+  String get documentParser => '文档解析';
+
+  @override
+  String get documentParserDesc => '智能分析文档内容';
+
+  @override
+  String get aiWritingAssistant => 'AI写作助手';
+
+  @override
+  String get aiWritingAssistantDesc => '让你的文章更专业';
+
+  @override
+  String get smartReminder => '智能提醒';
+
+  @override
+  String get smartReminderDesc => '不错过重要事项';
+
+  @override
+  String get voiceNotes => '语音笔记';
+
+  @override
+  String get voiceNotesDesc => '随时随地记录灵感';
+
+  @override
+  String get underDevelopment => '功能开发中';
+
+  @override
+  String get appearance => '外观';
+
+  @override
+  String get appearanceSettingsSubtitle => '调整应用的外观设置';
+
+  @override
+  String get fillAllFields => '请填写所有字段';
+
+  @override
+  String get difyConfigAdded => '已添加Dify配置';
+
+  @override
+  String get addNewDifyConfig => '添加新的Dify API配置';
+
+  @override
+  String get editDifyConfig => '编辑Dify配置';
+
+  @override
+  String get apiAddress => 'API地址';
+
+  @override
+  String get apiKey => 'API密钥';
+
+  @override
+  String get configName => '配置名称';
+
+  @override
+  String get inputConfigName => '输入配置名称';
+
+  @override
+  String get difyConfigUpdated => '已更新Dify配置';
+
+  @override
+  String get deleteDifyConfig => '删除Dify配置';
+
+  @override
+  String get confirmDeleteDify => '确定要删除配置吗？这个操作不可撤销。';
+
+  @override
+  String get configDeleted => '已删除配置';
+
+  @override
+  String get noDifyConfig => '暂无Dify配置，点击右上角添加';
+
+  @override
+  String get minimaxConfigAdded => '已添加MiniMax配置';
+
+  @override
+  String get addNewMinimaxConfig => '添加新的MiniMax AI配置';
+
+  @override
+  String get editMinimaxConfig => '编辑MiniMax配置';
+
+  @override
+  String get minimaxConfigUpdated => '已更新MiniMax配置';
+
+  @override
+  String get deleteMinimaxConfig => '删除MiniMax配置';
+
+  @override
+  String get confirmDeleteMinimax => '确定要删除配置吗？';
+
+  @override
+  String get noMinimaxConfig => '暂无MiniMax配置，点击右上角添加';
+
+  @override
+  String get model => '模型';
+
+  @override
+  String get xiaozhiServiceConfig => '小智服务配置';
+
+  @override
+  String get xiaozhiServiceConfigSubtitle => '管理小智语音服务配置';
+
+  @override
+  String get addXiaozhiService => '添加小智服务';
+
+  @override
+  String get addNewXiaozhiServiceConfig => '添加新的小智语音服务配置';
+
+  @override
+  String get editXiaozhiService => '编辑小智服务';
+
+  @override
+  String get modifyXiaozhiServiceConfig => '修改小智语音服务配置';
+
+  @override
+  String get serviceName => '服务名称';
+
+  @override
+  String get inputServiceName => '例如：家庭小智';
+
+  @override
+  String get websocketAddress => 'WebSocket地址';
+
+  @override
+  String get inputWebsocketAddress => '例如：wss://example.com';
+
+  @override
+  String get macAddress => 'MAC地址';
+
+  @override
+  String get macAddressOptional => 'MAC地址 (可选)';
+
+  @override
+  String get autoGenerate => '留空将自动生成';
+
+  @override
+  String get autoGenerateDesc => '留空将根据设备ID自动生成';
+
+  @override
+  String get token => 'Token';
+
+  @override
+  String get enabledByDefault => '默认开启';
+
+  @override
+  String get fillRequiredFields => '请填写所有必填字段';
+
+  @override
+  String get xiaozhiServiceAdded => '小智服务已添加';
+
+  @override
+  String get xiaozhiServiceUpdated => '小智服务已更新';
+
+  @override
+  String get deleteXiaozhiService => '删除小智服务';
+
+  @override
+  String get confirmDeleteXiaozhi => '确定要删除服务吗？';
+
+  @override
+  String get xiaozhiServiceDeleted => '小智服务已删除';
+
+  @override
+  String get addService => '添加服务';
+
+  @override
+  String get noXiaozhiService => '暂无小智服务，点击右上角添加';
+
+  @override
+  String get unconfigured => '未设置';
+
+  @override
+  String get difyApiConfig => 'Dify API配置';
+
+  @override
+  String get difyApiConfigSubtitle => '配置并管理多个Dify API服务';
+
+  @override
+  String get minimaxAiConfig => 'MiniMax AI配置';
+
+  @override
+  String get minimaxAiConfigSubtitle => '配置并管理MiniMax API服务';
+
+  @override
+  String get add => '添加';
+
+  @override
+  String get addDifyConfig => '添加Dify配置';
+
+  @override
+  String get addMinimaxConfig => '添加MiniMax配置';
+
+  @override
+  String get enterApiKey => '输入API Key';
+
+  @override
+  String get enterMinimaxApiKey => '输入MiniMax API Key';
+
+  @override
+  String get wsExample => '例如：wss://example.com';
+}

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,0 +1,437 @@
+{
+  "@@locale": "ru",
+  "settings": "Настройки",
+  "@settings": {
+    "description": "Settings screen title"
+  },
+  "general": "Общие",
+  "@general": {
+    "description": "General settings tab"
+  },
+  "darkMode": "Тёмный режим",
+  "@darkMode": {
+    "description": "Dark mode toggle"
+  },
+  "addConfig": "Добавить конфиг",
+  "@addConfig": {
+    "description": "Add configuration button"
+  },
+  "dify": "Dify",
+  "@dify": {
+    "description": "Dify tab label"
+  },
+  "minimax": "MiniMax",
+  "@minimax": {
+    "description": "MiniMax tab label"
+  },
+  "xiaozhi": "Xiaozhi",
+  "@xiaozhi": {
+    "description": "Xiaozhi tab label"
+  },
+  "cancel": "Отмена",
+  "@cancel": {
+    "description": "Cancel button"
+  },
+  "confirm": "Подтвердить",
+  "@confirm": {
+    "description": "Confirm button"
+  },
+  "delete": "Удалить",
+  "@delete": {
+    "description": "Delete button"
+  },
+  "edit": "Редактировать",
+  "@edit": {
+    "description": "Edit button"
+  },
+  "save": "Сохранить",
+  "@save": {
+    "description": "Save button"
+  },
+  "messages": "Сообщения",
+  "@messages": {
+    "description": "Messages tab"
+  },
+  "discover": "Обзор",
+  "@discover": {
+    "description": "Discover tab"
+  },
+  "searchConversations": "Поиск диалогов",
+  "@searchConversations": {
+    "description": "Search conversations placeholder"
+  },
+  "pinConversation": "Закрепить диалог",
+  "@pinConversation": {
+    "description": "Pin conversation action"
+  },
+  "allConversations": "Все диалоги",
+  "@allConversations": {
+    "description": "All conversations label"
+  },
+  "noConversations": "Нет диалогов",
+  "@noConversations": {
+    "description": "No conversations empty state"
+  },
+  "discovery": "Обзор",
+  "@discovery": {
+    "description": "Discovery screen title"
+  },
+  "text": "Текст",
+  "@text": {
+    "description": "Text message type"
+  },
+  "voice": "Голос",
+  "@voice": {
+    "description": "Voice message type"
+  },
+  "yesterday": "Вчера",
+  "@yesterday": {
+    "description": "Yesterday label"
+  },
+  "language": "Язык",
+  "@language": {
+    "description": "Language selector label"
+  },
+  "createNewConversation": "Нажмите + чтобы создать новый диалог",
+  "@createNewConversation": {
+    "description": "Empty state instruction to create new conversation"
+  },
+  "deleted": "удалено",
+  "@deleted": {
+    "description": "Deleted confirmation suffix"
+  },
+  "undo": "Отменить",
+  "@undo": {
+    "description": "Undo action"
+  },
+  "unpinConversation": "Открепить диалог",
+  "@unpinConversation": {
+    "description": "Unpin conversation action"
+  },
+  "deleteConversation": "Удалить диалог",
+  "@deleteConversation": {
+    "description": "Delete conversation action"
+  },
+  "weekday1": "Пн",
+  "@weekday1": {
+    "description": "Monday"
+  },
+  "weekday2": "Вт",
+  "@weekday2": {
+    "description": "Tuesday"
+  },
+  "weekday3": "Ср",
+  "@weekday3": {
+    "description": "Wednesday"
+  },
+  "weekday4": "Чт",
+  "@weekday4": {
+    "description": "Thursday"
+  },
+  "weekday5": "Пт",
+  "@weekday5": {
+    "description": "Friday"
+  },
+  "weekday6": "Сб",
+  "@weekday6": {
+    "description": "Saturday"
+  },
+  "weekday7": "Вс",
+  "@weekday7": {
+    "description": "Sunday"
+  },
+  "practicalTools": "Практические инструменты",
+  "@practicalTools": {
+    "description": "Practical tools section header"
+  },
+  "featuredRecommendations": "Рекомендуемые",
+  "@featuredRecommendations": {
+    "description": "Featured recommendations section header"
+  },
+  "readingAssistant": "Ассистент чтения",
+  "@readingAssistant": {
+    "description": "Reading assistant card title"
+  },
+  "readingAssistantDesc": "Эффективное понимание и обобщение статей",
+  "@readingAssistantDesc": {
+    "description": "Reading assistant description"
+  },
+  "translationTool": "Инструмент перевода",
+  "@translationTool": {
+    "description": "Translation tool card title"
+  },
+  "translationToolDesc": "Мгновенный многоязычный перевод",
+  "@translationToolDesc": {
+    "description": "Translation tool description"
+  },
+  "voiceAssistant": "Голосовой ассистент",
+  "@voiceAssistant": {
+    "description": "Voice assistant card title"
+  },
+  "voiceAssistantDesc": "Интеллектуальное голосовое взаимодействие",
+  "@voiceAssistantDesc": {
+    "description": "Voice assistant description"
+  },
+  "documentParser": "Анализатор документов",
+  "@documentParser": {
+    "description": "Document parser card title"
+  },
+  "documentParserDesc": "Интеллектуальный анализ содержимого документов",
+  "@documentParserDesc": {
+    "description": "Document parser description"
+  },
+  "aiWritingAssistant": "AI-ассистент написания",
+  "@aiWritingAssistant": {
+    "description": "AI writing assistant card title"
+  },
+  "aiWritingAssistantDesc": "Сделайте ваши статьи более профессиональными",
+  "@aiWritingAssistantDesc": {
+    "description": "AI writing assistant description"
+  },
+  "smartReminder": "Умный напоминатель",
+  "@smartReminder": {
+    "description": "Smart reminder card title"
+  },
+  "smartReminderDesc": "Не пропустите важные дела",
+  "@smartReminderDesc": {
+    "description": "Smart reminder description"
+  },
+  "voiceNotes": "Голосовые заметки",
+  "@voiceNotes": {
+    "description": "Voice notes card title"
+  },
+  "voiceNotesDesc": "Записывайте идеи в любой момент",
+  "@voiceNotesDesc": {
+    "description": "Voice notes description"
+  },
+  "underDevelopment": "В разработке",
+  "@underDevelopment": {
+    "description": "Under development suffix for feature cards"
+  },
+  "appearance": "Внешний вид",
+  "@appearance": {
+    "description": "appearance string"
+  },
+  "appearanceSettingsSubtitle": "Настройка внешнего вида приложения",
+  "@appearanceSettingsSubtitle": {
+    "description": "appearanceSettingsSubtitle string"
+  },
+  "fillAllFields": "Пожалуйста, заполните все поля",
+  "@fillAllFields": {
+    "description": "fillAllFields string"
+  },
+  "difyConfigAdded": "Конфиг Dify добавлен",
+  "@difyConfigAdded": {
+    "description": "difyConfigAdded string"
+  },
+  "addNewDifyConfig": "Добавить новый конфиг Dify API",
+  "@addNewDifyConfig": {
+    "description": "addNewDifyConfig string"
+  },
+  "editDifyConfig": "Редактировать конфиг Dify",
+  "@editDifyConfig": {
+    "description": "editDifyConfig string"
+  },
+  "apiAddress": "Адрес API",
+  "@apiAddress": {
+    "description": "apiAddress string"
+  },
+  "apiKey": "Ключ API",
+  "@apiKey": {
+    "description": "apiKey string"
+  },
+  "configName": "Название конфига",
+  "@configName": {
+    "description": "configName string"
+  },
+  "inputConfigName": "Введите название конфига",
+  "@inputConfigName": {
+    "description": "inputConfigName string"
+  },
+  "difyConfigUpdated": "Конфиг Dify обновлён",
+  "@difyConfigUpdated": {
+    "description": "difyConfigUpdated string"
+  },
+  "deleteDifyConfig": "Удалить конфиг Dify",
+  "@deleteDifyConfig": {
+    "description": "deleteDifyConfig string"
+  },
+  "confirmDeleteDify": "Удалить этот конфиг? Это действие нельзя отменить.",
+  "@confirmDeleteDify": {
+    "description": "confirmDeleteDify string"
+  },
+  "configDeleted": "Конфиг удалён",
+  "@configDeleted": {
+    "description": "configDeleted string"
+  },
+  "noDifyConfig": "Нет конфига Dify, нажмите +",
+  "@noDifyConfig": {
+    "description": "noDifyConfig string"
+  },
+  "minimaxConfigAdded": "Конфиг MiniMax добавлен",
+  "@minimaxConfigAdded": {
+    "description": "minimaxConfigAdded string"
+  },
+  "addNewMinimaxConfig": "Добавить новый конфиг MiniMax AI",
+  "@addNewMinimaxConfig": {
+    "description": "addNewMinimaxConfig string"
+  },
+  "editMinimaxConfig": "Редактировать конфиг MiniMax",
+  "@editMinimaxConfig": {
+    "description": "editMinimaxConfig string"
+  },
+  "minimaxConfigUpdated": "Конфиг MiniMax обновлён",
+  "@minimaxConfigUpdated": {
+    "description": "minimaxConfigUpdated string"
+  },
+  "deleteMinimaxConfig": "Удалить конфиг MiniMax",
+  "@deleteMinimaxConfig": {
+    "description": "deleteMinimaxConfig string"
+  },
+  "confirmDeleteMinimax": "Удалить этот конфиг?",
+  "@confirmDeleteMinimax": {
+    "description": "confirmDeleteMinimax string"
+  },
+  "noMinimaxConfig": "Нет конфига MiniMax, нажмите +",
+  "@noMinimaxConfig": {
+    "description": "noMinimaxConfig string"
+  },
+  "model": "Модель",
+  "@model": {
+    "description": "model string"
+  },
+  "xiaozhiServiceConfig": "Конфиг сервиса Xiaozhi",
+  "@xiaozhiServiceConfig": {
+    "description": "xiaozhiServiceConfig string"
+  },
+  "xiaozhiServiceConfigSubtitle": "Управление конфигом голосового сервиса Xiaozhi",
+  "@xiaozhiServiceConfigSubtitle": {
+    "description": "xiaozhiServiceConfigSubtitle string"
+  },
+  "addXiaozhiService": "Добавить сервис Xiaozhi",
+  "@addXiaozhiService": {
+    "description": "addXiaozhiService string"
+  },
+  "addNewXiaozhiServiceConfig": "Добавить новый конфиг голосового сервиса Xiaozhi",
+  "@addNewXiaozhiServiceConfig": {
+    "description": "addNewXiaozhiServiceConfig string"
+  },
+  "editXiaozhiService": "Редактировать сервис Xiaozhi",
+  "@editXiaozhiService": {
+    "description": "editXiaozhiService string"
+  },
+  "modifyXiaozhiServiceConfig": "Изменить конфиг голосового сервиса Xiaozhi",
+  "@modifyXiaozhiServiceConfig": {
+    "description": "modifyXiaozhiServiceConfig string"
+  },
+  "serviceName": "Название сервиса",
+  "@serviceName": {
+    "description": "serviceName string"
+  },
+  "inputServiceName": "напр. Домашний Xiaozhi",
+  "@inputServiceName": {
+    "description": "inputServiceName string"
+  },
+  "websocketAddress": "WebSocket адрес",
+  "@websocketAddress": {
+    "description": "websocketAddress string"
+  },
+  "inputWebsocketAddress": "напр. wss://example.com",
+  "@inputWebsocketAddress": {
+    "description": "inputWebsocketAddress string"
+  },
+  "macAddress": "MAC адрес",
+  "@macAddress": {
+    "description": "macAddress string"
+  },
+  "macAddressOptional": "MAC адрес (опц.)",
+  "@macAddressOptional": {
+    "description": "macAddressOptional string"
+  },
+  "autoGenerate": "Оставьте пустым для автогенерации",
+  "@autoGenerate": {
+    "description": "autoGenerate string"
+  },
+  "autoGenerateDesc": "Автогенерация из ID устройства",
+  "@autoGenerateDesc": {
+    "description": "autoGenerateDesc string"
+  },
+  "token": "Токен",
+  "@token": {
+    "description": "token string"
+  },
+  "enabledByDefault": "Включено по умолчанию",
+  "@enabledByDefault": {
+    "description": "enabledByDefault string"
+  },
+  "fillRequiredFields": "Пожалуйста, заполните все обязательные поля",
+  "@fillRequiredFields": {
+    "description": "fillRequiredFields string"
+  },
+  "xiaozhiServiceAdded": "Сервис Xiaozhi добавлен",
+  "@xiaozhiServiceAdded": {
+    "description": "xiaozhiServiceAdded string"
+  },
+  "xiaozhiServiceUpdated": "Сервис Xiaozhi обновлён",
+  "@xiaozhiServiceUpdated": {
+    "description": "xiaozhiServiceUpdated string"
+  },
+  "deleteXiaozhiService": "Удалить сервис Xiaozhi",
+  "@deleteXiaozhiService": {
+    "description": "deleteXiaozhiService string"
+  },
+  "confirmDeleteXiaozhi": "Удалить этот сервис?",
+  "@confirmDeleteXiaozhi": {
+    "description": "confirmDeleteXiaozhi string"
+  },
+  "xiaozhiServiceDeleted": "Сервис Xiaozhi удалён",
+  "@xiaozhiServiceDeleted": {
+    "description": "xiaozhiServiceDeleted string"
+  },
+  "addService": "Добавить сервис",
+  "@addService": {
+    "description": "addService string"
+  },
+  "noXiaozhiService": "Нет сервиса Xiaozhi, нажмите +",
+  "@noXiaozhiService": {
+    "description": "noXiaozhiService string"
+  },
+  "unconfigured": "Не настроено",
+  "@unconfigured": {
+    "description": "unconfigured string"
+  },
+  "difyApiConfig": "Конфиг Dify API",
+  "@difyApiConfig": {
+    "description": "difyApiConfig string"
+  },
+  "difyApiConfigSubtitle": "Настройка и управление несколькими сервисами Dify API",
+  "@difyApiConfigSubtitle": {
+    "description": "difyApiConfigSubtitle string"
+  },
+  "minimaxAiConfig": "Конфиг MiniMax AI",
+  "@minimaxAiConfig": {
+    "description": "minimaxAiConfig string"
+  },
+  "minimaxAiConfigSubtitle": "Настройка и управление сервисами MiniMax API",
+  "@minimaxAiConfigSubtitle": {
+    "description": "minimaxAiConfigSubtitle string"
+  },
+  "add": "Добавить",
+  "@add": {
+    "description": "Add button"
+  },
+  "addDifyConfig": "Добавить конфиг Dify",
+  "@addDifyConfig": {
+    "description": "addDifyConfig string"
+  },
+  "addMinimaxConfig": "Добавить конфиг MiniMax",
+  "@addMinimaxConfig": {
+    "description": "addMinimaxConfig string"
+  },
+  "enterApiKey": "Введите API-ключ",
+  "@enterApiKey": {"description": "Hint text for API Key input field"},
+  "enterMinimaxApiKey": "Введите API-ключ MiniMax",
+  "@enterMinimaxApiKey": {"description": "Hint text for MiniMax API Key input"},
+  "wsExample": "например: wss://example.com",
+  "@wsExample": {"description": "Example WebSocket address hint"}
+}

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,0 +1,437 @@
+{
+  "@@locale": "zh",
+  "settings": "设置",
+  "@settings": {
+    "description": "Settings screen title"
+  },
+  "general": "通用",
+  "@general": {
+    "description": "General settings tab"
+  },
+  "darkMode": "深色模式",
+  "@darkMode": {
+    "description": "Dark mode toggle"
+  },
+  "addConfig": "添加配置",
+  "@addConfig": {
+    "description": "Add configuration button"
+  },
+  "dify": "Dify",
+  "@dify": {
+    "description": "Dify tab label"
+  },
+  "minimax": "MiniMax",
+  "@minimax": {
+    "description": "MiniMax tab label"
+  },
+  "xiaozhi": "小智",
+  "@xiaozhi": {
+    "description": "Xiaozhi tab label"
+  },
+  "cancel": "取消",
+  "@cancel": {
+    "description": "Cancel button"
+  },
+  "confirm": "确认",
+  "@confirm": {
+    "description": "Confirm button"
+  },
+  "delete": "删除",
+  "@delete": {
+    "description": "Delete button"
+  },
+  "edit": "编辑",
+  "@edit": {
+    "description": "Edit button"
+  },
+  "save": "保存",
+  "@save": {
+    "description": "Save button"
+  },
+  "messages": "消息",
+  "@messages": {
+    "description": "Messages tab"
+  },
+  "discover": "发现",
+  "@discover": {
+    "description": "Discover tab"
+  },
+  "searchConversations": "搜索对话",
+  "@searchConversations": {
+    "description": "Search conversations placeholder"
+  },
+  "pinConversation": "置顶对话",
+  "@pinConversation": {
+    "description": "Pin conversation action"
+  },
+  "allConversations": "全部对话",
+  "@allConversations": {
+    "description": "All conversations label"
+  },
+  "noConversations": "没有对话",
+  "@noConversations": {
+    "description": "No conversations empty state"
+  },
+  "discovery": "发现",
+  "@discovery": {
+    "description": "Discovery screen title"
+  },
+  "text": "文本",
+  "@text": {
+    "description": "Text message type"
+  },
+  "voice": "语音",
+  "@voice": {
+    "description": "Voice message type"
+  },
+  "yesterday": "昨天",
+  "@yesterday": {
+    "description": "Yesterday label"
+  },
+  "language": "语言",
+  "@language": {
+    "description": "Language selector label"
+  },
+  "createNewConversation": "点击 + 创建新对话",
+  "@createNewConversation": {
+    "description": "Empty state instruction to create new conversation"
+  },
+  "deleted": "已删除",
+  "@deleted": {
+    "description": "Deleted confirmation suffix"
+  },
+  "undo": "撤销",
+  "@undo": {
+    "description": "Undo action"
+  },
+  "unpinConversation": "取消置顶",
+  "@unpinConversation": {
+    "description": "Unpin conversation action"
+  },
+  "deleteConversation": "删除对话",
+  "@deleteConversation": {
+    "description": "Delete conversation action"
+  },
+  "weekday1": "一",
+  "@weekday1": {
+    "description": "Monday"
+  },
+  "weekday2": "二",
+  "@weekday2": {
+    "description": "Tuesday"
+  },
+  "weekday3": "三",
+  "@weekday3": {
+    "description": "Wednesday"
+  },
+  "weekday4": "四",
+  "@weekday4": {
+    "description": "Thursday"
+  },
+  "weekday5": "五",
+  "@weekday5": {
+    "description": "Friday"
+  },
+  "weekday6": "六",
+  "@weekday6": {
+    "description": "Saturday"
+  },
+  "weekday7": "日",
+  "@weekday7": {
+    "description": "Sunday"
+  },
+  "practicalTools": "实用工具",
+  "@practicalTools": {
+    "description": "Practical tools section header"
+  },
+  "featuredRecommendations": "精选推荐",
+  "@featuredRecommendations": {
+    "description": "Featured recommendations section header"
+  },
+  "readingAssistant": "阅读助手",
+  "@readingAssistant": {
+    "description": "Reading assistant card title"
+  },
+  "readingAssistantDesc": "高效理解和总结文章",
+  "@readingAssistantDesc": {
+    "description": "Reading assistant description"
+  },
+  "translationTool": "翻译工具",
+  "@translationTool": {
+    "description": "Translation tool card title"
+  },
+  "translationToolDesc": "多语言实时翻译",
+  "@translationToolDesc": {
+    "description": "Translation tool description"
+  },
+  "voiceAssistant": "语音助手",
+  "@voiceAssistant": {
+    "description": "Voice assistant card title"
+  },
+  "voiceAssistantDesc": "智能语音交互",
+  "@voiceAssistantDesc": {
+    "description": "Voice assistant description"
+  },
+  "documentParser": "文档解析",
+  "@documentParser": {
+    "description": "Document parser card title"
+  },
+  "documentParserDesc": "智能分析文档内容",
+  "@documentParserDesc": {
+    "description": "Document parser description"
+  },
+  "aiWritingAssistant": "AI写作助手",
+  "@aiWritingAssistant": {
+    "description": "AI writing assistant card title"
+  },
+  "aiWritingAssistantDesc": "让你的文章更专业",
+  "@aiWritingAssistantDesc": {
+    "description": "AI writing assistant description"
+  },
+  "smartReminder": "智能提醒",
+  "@smartReminder": {
+    "description": "Smart reminder card title"
+  },
+  "smartReminderDesc": "不错过重要事项",
+  "@smartReminderDesc": {
+    "description": "Smart reminder description"
+  },
+  "voiceNotes": "语音笔记",
+  "@voiceNotes": {
+    "description": "Voice notes card title"
+  },
+  "voiceNotesDesc": "随时随地记录灵感",
+  "@voiceNotesDesc": {
+    "description": "Voice notes description"
+  },
+  "underDevelopment": "功能开发中",
+  "@underDevelopment": {
+    "description": "Under development suffix for feature cards"
+  },
+  "appearance": "外观",
+  "@appearance": {
+    "description": "appearance string"
+  },
+  "appearanceSettingsSubtitle": "调整应用的外观设置",
+  "@appearanceSettingsSubtitle": {
+    "description": "appearanceSettingsSubtitle string"
+  },
+  "fillAllFields": "请填写所有字段",
+  "@fillAllFields": {
+    "description": "fillAllFields string"
+  },
+  "difyConfigAdded": "已添加Dify配置",
+  "@difyConfigAdded": {
+    "description": "difyConfigAdded string"
+  },
+  "addNewDifyConfig": "添加新的Dify API配置",
+  "@addNewDifyConfig": {
+    "description": "addNewDifyConfig string"
+  },
+  "editDifyConfig": "编辑Dify配置",
+  "@editDifyConfig": {
+    "description": "editDifyConfig string"
+  },
+  "apiAddress": "API地址",
+  "@apiAddress": {
+    "description": "apiAddress string"
+  },
+  "apiKey": "API密钥",
+  "@apiKey": {
+    "description": "apiKey string"
+  },
+  "configName": "配置名称",
+  "@configName": {
+    "description": "configName string"
+  },
+  "inputConfigName": "输入配置名称",
+  "@inputConfigName": {
+    "description": "inputConfigName string"
+  },
+  "difyConfigUpdated": "已更新Dify配置",
+  "@difyConfigUpdated": {
+    "description": "difyConfigUpdated string"
+  },
+  "deleteDifyConfig": "删除Dify配置",
+  "@deleteDifyConfig": {
+    "description": "deleteDifyConfig string"
+  },
+  "confirmDeleteDify": "确定要删除配置吗？这个操作不可撤销。",
+  "@confirmDeleteDify": {
+    "description": "confirmDeleteDify string"
+  },
+  "configDeleted": "已删除配置",
+  "@configDeleted": {
+    "description": "configDeleted string"
+  },
+  "noDifyConfig": "暂无Dify配置，点击右上角添加",
+  "@noDifyConfig": {
+    "description": "noDifyConfig string"
+  },
+  "minimaxConfigAdded": "已添加MiniMax配置",
+  "@minimaxConfigAdded": {
+    "description": "minimaxConfigAdded string"
+  },
+  "addNewMinimaxConfig": "添加新的MiniMax AI配置",
+  "@addNewMinimaxConfig": {
+    "description": "addNewMinimaxConfig string"
+  },
+  "editMinimaxConfig": "编辑MiniMax配置",
+  "@editMinimaxConfig": {
+    "description": "editMinimaxConfig string"
+  },
+  "minimaxConfigUpdated": "已更新MiniMax配置",
+  "@minimaxConfigUpdated": {
+    "description": "minimaxConfigUpdated string"
+  },
+  "deleteMinimaxConfig": "删除MiniMax配置",
+  "@deleteMinimaxConfig": {
+    "description": "deleteMinimaxConfig string"
+  },
+  "confirmDeleteMinimax": "确定要删除配置吗？",
+  "@confirmDeleteMinimax": {
+    "description": "confirmDeleteMinimax string"
+  },
+  "noMinimaxConfig": "暂无MiniMax配置，点击右上角添加",
+  "@noMinimaxConfig": {
+    "description": "noMinimaxConfig string"
+  },
+  "model": "模型",
+  "@model": {
+    "description": "model string"
+  },
+  "xiaozhiServiceConfig": "小智服务配置",
+  "@xiaozhiServiceConfig": {
+    "description": "xiaozhiServiceConfig string"
+  },
+  "xiaozhiServiceConfigSubtitle": "管理小智语音服务配置",
+  "@xiaozhiServiceConfigSubtitle": {
+    "description": "xiaozhiServiceConfigSubtitle string"
+  },
+  "addXiaozhiService": "添加小智服务",
+  "@addXiaozhiService": {
+    "description": "addXiaozhiService string"
+  },
+  "addNewXiaozhiServiceConfig": "添加新的小智语音服务配置",
+  "@addNewXiaozhiServiceConfig": {
+    "description": "addNewXiaozhiServiceConfig string"
+  },
+  "editXiaozhiService": "编辑小智服务",
+  "@editXiaozhiService": {
+    "description": "editXiaozhiService string"
+  },
+  "modifyXiaozhiServiceConfig": "修改小智语音服务配置",
+  "@modifyXiaozhiServiceConfig": {
+    "description": "modifyXiaozhiServiceConfig string"
+  },
+  "serviceName": "服务名称",
+  "@serviceName": {
+    "description": "serviceName string"
+  },
+  "inputServiceName": "例如：家庭小智",
+  "@inputServiceName": {
+    "description": "inputServiceName string"
+  },
+  "websocketAddress": "WebSocket地址",
+  "@websocketAddress": {
+    "description": "websocketAddress string"
+  },
+  "inputWebsocketAddress": "例如：wss://example.com",
+  "@inputWebsocketAddress": {
+    "description": "inputWebsocketAddress string"
+  },
+  "macAddress": "MAC地址",
+  "@macAddress": {
+    "description": "macAddress string"
+  },
+  "macAddressOptional": "MAC地址 (可选)",
+  "@macAddressOptional": {
+    "description": "macAddressOptional string"
+  },
+  "autoGenerate": "留空将自动生成",
+  "@autoGenerate": {
+    "description": "autoGenerate string"
+  },
+  "autoGenerateDesc": "留空将根据设备ID自动生成",
+  "@autoGenerateDesc": {
+    "description": "autoGenerateDesc string"
+  },
+  "token": "Token",
+  "@token": {
+    "description": "token string"
+  },
+  "enabledByDefault": "默认开启",
+  "@enabledByDefault": {
+    "description": "enabledByDefault string"
+  },
+  "fillRequiredFields": "请填写所有必填字段",
+  "@fillRequiredFields": {
+    "description": "fillRequiredFields string"
+  },
+  "xiaozhiServiceAdded": "小智服务已添加",
+  "@xiaozhiServiceAdded": {
+    "description": "xiaozhiServiceAdded string"
+  },
+  "xiaozhiServiceUpdated": "小智服务已更新",
+  "@xiaozhiServiceUpdated": {
+    "description": "xiaozhiServiceUpdated string"
+  },
+  "deleteXiaozhiService": "删除小智服务",
+  "@deleteXiaozhiService": {
+    "description": "deleteXiaozhiService string"
+  },
+  "confirmDeleteXiaozhi": "确定要删除服务吗？",
+  "@confirmDeleteXiaozhi": {
+    "description": "confirmDeleteXiaozhi string"
+  },
+  "xiaozhiServiceDeleted": "小智服务已删除",
+  "@xiaozhiServiceDeleted": {
+    "description": "xiaozhiServiceDeleted string"
+  },
+  "addService": "添加服务",
+  "@addService": {
+    "description": "addService string"
+  },
+  "noXiaozhiService": "暂无小智服务，点击右上角添加",
+  "@noXiaozhiService": {
+    "description": "noXiaozhiService string"
+  },
+  "unconfigured": "未设置",
+  "@unconfigured": {
+    "description": "unconfigured string"
+  },
+  "difyApiConfig": "Dify API配置",
+  "@difyApiConfig": {
+    "description": "difyApiConfig string"
+  },
+  "difyApiConfigSubtitle": "配置并管理多个Dify API服务",
+  "@difyApiConfigSubtitle": {
+    "description": "difyApiConfigSubtitle string"
+  },
+  "minimaxAiConfig": "MiniMax AI配置",
+  "@minimaxAiConfig": {
+    "description": "minimaxAiConfig string"
+  },
+  "minimaxAiConfigSubtitle": "配置并管理MiniMax API服务",
+  "@minimaxAiConfigSubtitle": {
+    "description": "minimaxAiConfigSubtitle string"
+  },
+  "add": "添加",
+  "@add": {
+    "description": "Add button"
+  },
+  "addDifyConfig": "添加Dify配置",
+  "@addDifyConfig": {
+    "description": "addDifyConfig string"
+  },
+  "addMinimaxConfig": "添加MiniMax配置",
+  "@addMinimaxConfig": {
+    "description": "addMinimaxConfig string"
+  },
+  "enterApiKey": "输入API Key",
+  "@enterApiKey": {"description": "Hint text for API Key input field"},
+  "enterMinimaxApiKey": "输入MiniMax API Key",
+  "@enterMinimaxApiKey": {"description": "Hint text for MiniMax API Key input"},
+  "wsExample": "例如：wss://example.com",
+  "@wsExample": {"description": "Example WebSocket address hint"}
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,9 @@ import 'dart:io';
 import 'dart:ui';
 import 'package:ai_assistant/utils/audio_util.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
+import 'package:ai_assistant/providers/locale_provider.dart';
+import 'package:ai_assistant/l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 // 是否启用调试工具
 const bool enableDebugTools = true;
@@ -55,9 +58,10 @@ void main() async {
     ].request();
   }
 
-  // 添加中文本地化支持
+  // 添加本地化支持 (英语/中文/俄语)
+  timeago.setLocaleMessages('en', timeago.EnMessages());
   timeago.setLocaleMessages('zh', timeago.ZhMessages());
-  timeago.setDefaultLocale('zh');
+  timeago.setLocaleMessages('ru', timeago.RuMessages());
 
   // 在Android上设置高刷新率
   if (Platform.isAndroid) {
@@ -102,14 +106,19 @@ void main() async {
   // 初始化配置管理
   final configProvider = ConfigProvider();
 
+  // 初始化LocaleProvider
+  final localeProvider = LocaleProvider();
+  await localeProvider.loadLocale();
+
   runApp(
     MultiProvider(
       providers: [
+        ChangeNotifierProvider.value(value: localeProvider),
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
         ChangeNotifierProvider.value(value: configProvider),
         ChangeNotifierProvider(create: (_) => ConversationProvider()),
       ],
-      child: const MyApp(),
+      child: MyApp(localeProvider: localeProvider),
     ),
   );
 }
@@ -140,14 +149,62 @@ Future<void> _setupSystemUI() async {
   }
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class MyApp extends StatefulWidget {
+  final LocaleProvider localeProvider;
+  const MyApp({super.key, required this.localeProvider});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _updateTimeagoLocale();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _updateTimeagoLocale();
+  }
+
+  void _updateTimeagoLocale() {
+    final locale = widget.localeProvider.locale.languageCode;
+    timeago.setDefaultLocale(locale);
+  }
 
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
-
     return MaterialApp(
+      locale: widget.localeProvider.locale,
+      localizationsDelegates: [
+        S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('zh'),
+        Locale('ru'),
+      ],
+      localeResolutionCallback: (locale, supportedLocales) {
+        if (locale == null) return const Locale('en');
+        if (supportedLocales.any((s) => s.languageCode == locale.languageCode)) {
+          return locale;
+        }
+        return const Locale('en');
+      },
       title: 'AI-LHHT',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.lightTheme,
@@ -155,16 +212,12 @@ class MyApp extends StatelessWidget {
       themeMode: themeProvider.themeMode,
       home: const HomeScreen(),
       routes: {
-        // 添加测试界面路由
         '/test': (context) => const TestScreen(),
       },
-      // 添加平滑滚动设置
       scrollBehavior: const MaterialScrollBehavior().copyWith(
-        // 启用物理滚动
         physics: const BouncingScrollPhysics(
           parent: AlwaysScrollableScrollPhysics(),
         ),
-        // 确保所有平台都有滚动条和弹性效果
         dragDevices: {
           PointerDeviceKind.touch,
           PointerDeviceKind.mouse,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,12 +46,14 @@ void main() async {
         100 * 1024 * 1024; // 100 MB
   }
 
-  // 请求录音和存储权限
-  await [
-    Permission.microphone,
-    Permission.storage,
-    if (Platform.isAndroid) Permission.bluetoothConnect,
-  ].request();
+  // 请求录音和存储权限 (macOS不适用permission_handler)
+  if (!Platform.isMacOS) {
+    await [
+      Permission.microphone,
+      Permission.storage,
+      if (Platform.isAndroid) Permission.bluetoothConnect,
+    ].request();
+  }
 
   // 添加中文本地化支持
   timeago.setLocaleMessages('zh', timeago.ZhMessages());

--- a/lib/providers/locale_provider.dart
+++ b/lib/providers/locale_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocaleProvider extends ChangeNotifier {
+  static const String _localeKey = 'app_locale';
+  Locale _locale = const Locale('zh');
+
+  Locale get locale => _locale;
+
+  LocaleProvider() {
+    _loadLocale();
+  }
+
+  Future<void> _loadLocale() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedLocale = prefs.getString(_localeKey);
+    if (savedLocale != null) {
+      _locale = Locale(savedLocale);
+    } else {
+      _locale = const Locale('zh');
+    }
+    notifyListeners();
+  }
+
+  Future<void> loadLocale() async {
+    await _loadLocale();
+  }
+
+  Future<void> setLocale(Locale newLocale) async {
+    _locale = newLocale;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_localeKey, newLocale.languageCode);
+    notifyListeners();
+  }
+}

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -1299,7 +1299,7 @@ class _ChatScreenState extends State<ChatScreen> {
       await conversationProvider.addMessage(
         conversationId: widget.conversation.id,
         role: MessageRole.assistant,
-        content: '发生错误: ${e.toString()}',
+        content: _buildSendErrorMessage(e),
       );
     } finally {
       if (!mounted) return;
@@ -1310,6 +1310,14 @@ class _ChatScreenState extends State<ChatScreen> {
 
       _scrollToBottom();
     }
+  }
+
+  String _buildSendErrorMessage(Object error) {
+    if (error is MiniMaxNetworkException) {
+      return error.message;
+    }
+
+    return '发生错误: ${error.toString()}';
   }
 
   void _scrollToBottom() {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -10,6 +10,7 @@ import 'package:ai_assistant/widgets/conversation_tile.dart';
 import 'package:ai_assistant/widgets/slidable_delete_tile.dart';
 import 'package:ai_assistant/widgets/discovery_screen.dart';
 import 'package:flutter/rendering.dart';
+import 'package:ai_assistant/l10n/app_localizations.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -45,8 +46,8 @@ class _HomeScreenState extends State<HomeScreen> {
             _selectedIndex == 1
                 ? null
                 : AppBar(
-                  title: const Text(
-                    '消息',
+                  title: Text(
+                    S.of(context)!.messages,
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
                       fontSize: 28,
@@ -225,7 +226,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           ),
                         ),
                       ),
-                      label: '消息',
+                      label: S.of(context)!.messages,
                     ),
                     BottomNavigationBarItem(
                       icon: Material(
@@ -257,7 +258,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           ),
                         ),
                       ),
-                      label: '发现',
+                      label: S.of(context)!.discover,
                     ),
                   ],
                 ),
@@ -295,7 +296,7 @@ class _HomeScreenState extends State<HomeScreen> {
           child: TextField(
             focusNode: _searchFocusNode,
             decoration: InputDecoration(
-              hintText: '搜索对话',
+              hintText: S.of(context)!.searchConversations,
               hintStyle: TextStyle(color: Colors.grey.shade400, fontSize: 16),
               prefixIcon: Container(
                 padding: const EdgeInsets.all(12),
@@ -342,7 +343,7 @@ class _HomeScreenState extends State<HomeScreen> {
           ),
           children: [
             if (pinnedConversations.isNotEmpty) ...[
-              const Padding(
+              Padding(
                 padding: EdgeInsets.only(
                   left: 20,
                   right: 20,
@@ -350,7 +351,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   bottom: 8,
                 ),
                 child: Text(
-                  '置顶对话',
+                  S.of(context)!.pinConversation,
                   style: TextStyle(
                     fontWeight: FontWeight.w500,
                     color: Colors.grey,
@@ -378,8 +379,8 @@ class _HomeScreenState extends State<HomeScreen> {
                   top: pinnedConversations.isEmpty ? 8 : 16,
                   bottom: 8,
                 ),
-                child: const Text(
-                  '全部对话',
+                child: Text(
+                  S.of(context)!.allConversations,
                   style: TextStyle(
                     fontWeight: FontWeight.w500,
                     color: Colors.grey,
@@ -428,7 +429,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                       const SizedBox(height: 24),
                       Text(
-                        '没有对话',
+                        S.of(context)!.noConversations,
                         style: TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.w500,
@@ -470,7 +471,7 @@ class _HomeScreenState extends State<HomeScreen> {
                             ),
                             const SizedBox(width: 8),
                             Text(
-                              '点击 + 创建新对话',
+                              S.of(context)!.createNewConversation,
                               style: TextStyle(
                                 fontSize: 14,
                                 color: Colors.grey.shade500,
@@ -503,7 +504,7 @@ class _HomeScreenState extends State<HomeScreen> {
         ScaffoldMessenger.of(context).clearSnackBars();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('${conversation.title} 已删除'),
+            content: Text('${conversation.title} ${S.of(context)!.deleted}'),
             backgroundColor: Colors.grey.shade800,
             behavior: SnackBarBehavior.floating,
             duration: const Duration(seconds: 3),
@@ -512,7 +513,7 @@ class _HomeScreenState extends State<HomeScreen> {
               borderRadius: BorderRadius.circular(10),
             ),
             action: SnackBarAction(
-              label: '撤销',
+              label: S.of(context)!.undo,
               textColor: Colors.white,
               onPressed: () {
                 // 恢复被删除的对话
@@ -626,7 +627,9 @@ class _HomeScreenState extends State<HomeScreen> {
                         ),
                       ),
                       title: Text(
-                        conversation.isPinned ? '取消置顶' : '置顶对话',
+                        conversation.isPinned
+                            ? S.of(context)!.unpinConversation
+                            : S.of(context)!.pinConversation,
                         style: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -692,8 +695,8 @@ class _HomeScreenState extends State<HomeScreen> {
                           size: 24,
                         ),
                       ),
-                      title: const Text(
-                        '删除对话',
+                      title: Text(
+                        S.of(context)!.deleteConversation,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -711,7 +714,9 @@ class _HomeScreenState extends State<HomeScreen> {
                         ).deleteConversation(conversation.id);
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: Text('${conversation.title} 已删除'),
+                            content: Text(
+                              '${conversation.title} ${S.of(context)!.deleted}',
+                            ),
                             backgroundColor: Colors.grey.shade800,
                             behavior: SnackBarBehavior.floating,
                             shape: RoundedRectangleBorder(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,10 +4,12 @@ import 'package:provider/provider.dart';
 import 'package:ai_assistant/providers/theme_provider.dart';
 import 'package:ai_assistant/providers/config_provider.dart';
 import 'package:ai_assistant/models/xiaozhi_config.dart';
+import 'package:ai_assistant/providers/locale_provider.dart';
 import 'package:ai_assistant/models/dify_config.dart';
 import 'package:ai_assistant/models/minimax_config.dart';
 import 'package:ai_assistant/widgets/settings_section.dart';
 import 'package:ai_assistant/services/dify_service.dart';
+import 'package:ai_assistant/l10n/app_localizations.dart';
 
 // 引入main.dart中定义的常量
 import 'package:ai_assistant/main.dart' show enableDebugTools;
@@ -87,8 +89,8 @@ class _SettingsScreenState extends State<SettingsScreen>
           icon: const Icon(Icons.arrow_back, color: Colors.black, size: 26),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        title: const Text(
-          '设置',
+        title: Text(
+          S.of(context)!.settings,
           style: TextStyle(
             color: Colors.black,
             fontWeight: FontWeight.bold,
@@ -166,7 +168,7 @@ class _SettingsScreenState extends State<SettingsScreen>
             fontWeight: FontWeight.w500,
             fontSize: 16,
           ),
-          tabs: const [Tab(text: '通用'), Tab(text: 'Dify'), Tab(text: 'MiniMax'), Tab(text: '小智')],
+          tabs: [Tab(text: S.of(context)!.general), Tab(text: S.of(context)!.dify), Tab(text: S.of(context)!.minimax), Tab(text: S.of(context)!.xiaozhi)],
         ),
       ),
     );
@@ -180,8 +182,8 @@ class _SettingsScreenState extends State<SettingsScreen>
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildCard(
-              title: '外观',
-              subtitle: '调整应用的外观设置',
+              title: S.of(context)!.appearance,
+              subtitle: S.of(context)!.appearanceSettingsSubtitle,
               child: Column(
                 children: [
                   Consumer<ThemeProvider>(
@@ -205,9 +207,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                                     size: 22,
                                   ),
                                 ),
-                                const SizedBox(width: 12),
-                                const Text(
-                                  '深色模式',
+                                SizedBox(width: 12),
+                                Text(                                  S.of(context)!.darkMode,
                                   style: TextStyle(
                                     fontSize: 16,
                                     fontWeight: FontWeight.w500,
@@ -222,6 +223,56 @@ class _SettingsScreenState extends State<SettingsScreen>
                               },
                               activeColor: Colors.black,
                               inactiveTrackColor: const Color(0xFFE0E0E0),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                  Consumer<LocaleProvider>(
+                    builder: (context, localeProvider, child) {
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 20,
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Row(
+                              children: [
+                                Container(
+                                  width: 24,
+                                  height: 24,
+                                  child: const Icon(
+                                    Icons.language,
+                                    color: Colors.black,
+                                    size: 22,
+                                  ),
+                                ),
+                                SizedBox(width: 12),
+                                Text(
+                                  S.of(context)!.language,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            DropdownButton<Locale>(
+                              value: localeProvider.locale,
+                              underline: const SizedBox(),
+                              items: [
+                                DropdownMenuItem(value: const Locale('zh'), child: Text('中文')),
+                                DropdownMenuItem(value: const Locale('en'), child: Text('English')),
+                                DropdownMenuItem(value: const Locale('ru'), child: Text('Русский')),
+                              ],
+                              onChanged: (locale) {
+                                if (locale != null) {
+                                  localeProvider.setLocale(locale);
+                                }
+                              },
                             ),
                           ],
                         ),
@@ -248,13 +299,12 @@ class _SettingsScreenState extends State<SettingsScreen>
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _buildCard(
-                title: 'Dify API配置',
-                subtitle: '配置并管理多个Dify API服务',
+                title: S.of(context)!.difyApiConfig,
+                subtitle: S.of(context)!.difyApiConfigSubtitle,
                 actionButton: ElevatedButton.icon(
                   onPressed: _showAddDifyDialog,
                   icon: const Icon(Icons.add, color: Colors.white, size: 18),
-                  label: const Text(
-                    '添加配置',
+                  label: Text(                    S.of(context)!.addConfig,
                     style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
                   ),
                   style: ElevatedButton.styleFrom(
@@ -274,9 +324,9 @@ class _SettingsScreenState extends State<SettingsScreen>
                 child: Column(
                   children: [
                     if (difyConfigs.isEmpty)
-                      const Padding(
+                      Padding(
                         padding: EdgeInsets.all(16),
-                        child: Center(child: Text('暂无Dify配置，点击右上角添加')),
+                        child: Center(child: Text(S.of(context)!.noDifyConfig)),
                       )
                     else
                       ...difyConfigs.map(
@@ -470,8 +520,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '添加Dify配置',
+                        Text(                          S.of(context)!.addDifyConfig,
                           style: TextStyle(
                             fontSize: 22,
                             fontWeight: FontWeight.bold,
@@ -498,14 +547,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
-                    const Text(
-                      '添加新的Dify API配置',
+                    SizedBox(height: 8),
+                    Text(                      S.of(context)!.addNewDifyConfig,
                       style: TextStyle(color: Colors.grey, fontSize: 14),
                     ),
-                    const SizedBox(height: 24),
-                    const Text(
-                      '配置名称',
+                    SizedBox(height: 24),
+                    Text(                      S.of(context)!.configName,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -529,7 +576,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       child: TextField(
                         controller: _newDifyNameController,
                         decoration: InputDecoration(
-                          hintText: '输入配置名称',
+                          hintText: S.of(context)!.inputConfigName,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -602,7 +649,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         controller: _newDifyApiKeyController,
                         obscureText: true,
                         decoration: InputDecoration(
-                          hintText: '输入API Key',
+                          hintText: S.of(context)!.enterApiKey,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -612,7 +659,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ),
                     ),
-                    const SizedBox(height: 24),
+                    SizedBox(height: 24),
                     ElevatedButton(
                       onPressed: () async {
                         final name = _newDifyNameController.text.trim();
@@ -621,7 +668,7 @@ class _SettingsScreenState extends State<SettingsScreen>
 
                         if (name.isEmpty || apiUrl.isEmpty || apiKey.isEmpty) {
                           ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('请填写所有字段')),
+                            SnackBar(content: Text(S.of(context)!.fillAllFields)),
                           );
                           return;
                         }
@@ -634,7 +681,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         Navigator.of(context).pop();
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: const Text('已添加Dify配置'),
+                            content: Text(S.of(context)!.difyConfigAdded),
                             backgroundColor: Colors.green.shade600,
                             behavior: SnackBarBehavior.floating,
                             shape: RoundedRectangleBorder(
@@ -654,8 +701,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '添加',
+                      child: Text(
+                        S.of(context)!.add,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -673,8 +720,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '取消',
+                      child: Text(
+                        S.of(context)!.cancel,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
@@ -724,8 +771,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '编辑Dify配置',
+                        Text(                          S.of(context)!.editDifyConfig,
                           style: TextStyle(
                             fontSize: 22,
                             fontWeight: FontWeight.bold,
@@ -752,14 +798,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
-                    const Text(
-                      '修改Dify API配置',
+                    SizedBox(height: 8),
+                    Text(                      S.of(context)!.addNewDifyConfig,
                       style: TextStyle(color: Colors.grey, fontSize: 14),
                     ),
-                    const SizedBox(height: 24),
-                    const Text(
-                      '配置名称',
+                    SizedBox(height: 24),
+                    Text(                      S.of(context)!.configName,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -783,7 +827,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       child: TextField(
                         controller: _newDifyNameController,
                         decoration: InputDecoration(
-                          hintText: '输入配置名称',
+                          hintText: S.of(context)!.inputConfigName,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -856,7 +900,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         controller: _newDifyApiKeyController,
                         obscureText: true,
                         decoration: InputDecoration(
-                          hintText: '输入API Key',
+                          hintText: S.of(context)!.enterApiKey,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -876,7 +920,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         if (name.isEmpty || apiUrl.isEmpty || apiKey.isEmpty) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: const Text('请填写所有字段'),
+                              content: Text(S.of(context)!.fillAllFields),
                               backgroundColor: Colors.red.shade600,
                               behavior: SnackBarBehavior.floating,
                               shape: RoundedRectangleBorder(
@@ -903,7 +947,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         Navigator.of(context).pop();
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: const Text('已更新Dify配置'),
+                            content: Text(S.of(context)!.difyConfigUpdated),
                             backgroundColor: Colors.green.shade600,
                             behavior: SnackBarBehavior.floating,
                             shape: RoundedRectangleBorder(
@@ -923,8 +967,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '保存',
+                      child: Text(
+                        S.of(context)!.save,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -942,8 +986,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '取消',
+                      child: Text(
+                        S.of(context)!.cancel,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
@@ -988,8 +1032,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '删除Dify配置',
+                        Text(                          S.of(context)!.deleteDifyConfig,
                           style: TextStyle(
                             fontSize: 22,
                             fontWeight: FontWeight.bold,
@@ -1018,10 +1061,10 @@ class _SettingsScreenState extends State<SettingsScreen>
                             color: Colors.red.shade700,
                             size: 24,
                           ),
-                          const SizedBox(width: 12),
+                          SizedBox(width: 12),
                           Expanded(
                             child: Text(
-                              '确定要删除"${config.name}"配置吗？这个操作不可撤销。',
+                              '${S.of(context)!.confirmDeleteDify}',
                               style: TextStyle(
                                 fontSize: 16,
                                 color: Colors.red.shade900,
@@ -1052,7 +1095,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         Navigator.of(context).pop();
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: const Text('已删除配置'),
+                            content: Text(S.of(context)!.configDeleted),
                             backgroundColor: Colors.green.shade600,
                             behavior: SnackBarBehavior.floating,
                             shape: RoundedRectangleBorder(
@@ -1062,8 +1105,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ),
                         );
                       },
-                      child: const Text(
-                        '删除',
+                      child: Text(
+                        S.of(context)!.delete,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -1082,8 +1125,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '取消',
+                      child: Text(
+                        S.of(context)!.cancel,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
@@ -1109,13 +1152,12 @@ class _SettingsScreenState extends State<SettingsScreen>
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _buildCard(
-                title: 'MiniMax AI配置',
-                subtitle: '配置并管理MiniMax API服务',
+                title: S.of(context)!.minimaxAiConfig,
+                subtitle: S.of(context)!.minimaxAiConfigSubtitle,
                 actionButton: ElevatedButton.icon(
                   onPressed: _showAddMiniMaxDialog,
                   icon: const Icon(Icons.add, color: Colors.white, size: 18),
-                  label: const Text(
-                    '添加配置',
+                  label: Text(                    S.of(context)!.addConfig,
                     style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
                   ),
                   style: ElevatedButton.styleFrom(
@@ -1135,9 +1177,9 @@ class _SettingsScreenState extends State<SettingsScreen>
                 child: Column(
                   children: [
                     if (minimaxConfigs.isEmpty)
-                      const Padding(
+                      Padding(
                         padding: EdgeInsets.all(16),
-                        child: Center(child: Text('暂无MiniMax配置，点击右上角添加')),
+                        child: Center(child: Text(S.of(context)!.noMinimaxConfig)),
                       )
                     else
                       ...minimaxConfigs.map(
@@ -1332,8 +1374,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          const Text(
-                            '添加MiniMax配置',
+                          Text(                            S.of(context)!.addMinimaxConfig,
                             style: TextStyle(
                               fontSize: 22,
                               fontWeight: FontWeight.bold,
@@ -1353,14 +1394,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ),
                         ],
                       ),
-                      const SizedBox(height: 8),
-                      const Text(
-                        '添加新的MiniMax AI配置',
+                      SizedBox(height: 8),
+                      Text(                        S.of(context)!.addNewMinimaxConfig,
                         style: TextStyle(color: Colors.grey, fontSize: 14),
                       ),
-                      const SizedBox(height: 24),
-                      const Text(
-                        '配置名称',
+                      SizedBox(height: 24),
+                      Text(                        S.of(context)!.configName,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -1376,7 +1415,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         child: TextField(
                           controller: nameController,
                           decoration: InputDecoration(
-                            hintText: '例如：MiniMax AI',
+                            hintText: S.of(context)!.inputServiceName,
                             hintStyle: TextStyle(color: Colors.grey.shade400),
                             contentPadding: const EdgeInsets.symmetric(
                               horizontal: 16,
@@ -1405,7 +1444,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                           controller: apiKeyController,
                           obscureText: true,
                           decoration: InputDecoration(
-                            hintText: '输入MiniMax API Key',
+                            hintText: S.of(context)!.enterMinimaxApiKey,
                             hintStyle: TextStyle(color: Colors.grey.shade400),
                             contentPadding: const EdgeInsets.symmetric(
                               horizontal: 16,
@@ -1415,9 +1454,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ),
                         ),
                       ),
-                      const SizedBox(height: 16),
-                      const Text(
-                        '模型',
+                      SizedBox(height: 16),
+                      Text(                        S.of(context)!.model,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -1457,7 +1495,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ),
                         ),
                       ),
-                      const SizedBox(height: 24),
+                      SizedBox(height: 24),
                       ElevatedButton(
                         onPressed: () async {
                           final name = nameController.text.trim();
@@ -1465,7 +1503,7 @@ class _SettingsScreenState extends State<SettingsScreen>
 
                           if (name.isEmpty || apiKey.isEmpty) {
                             ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('请填写所有字段')),
+                              SnackBar(content: Text(S.of(context)!.fillAllFields)),
                             );
                             return;
                           }
@@ -1478,7 +1516,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                           Navigator.of(context).pop();
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: const Text('已添加MiniMax配置'),
+                              content: Text(S.of(context)!.minimaxConfigAdded),
                               backgroundColor: Colors.green.shade600,
                               behavior: SnackBarBehavior.floating,
                               shape: RoundedRectangleBorder(
@@ -1497,8 +1535,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                             borderRadius: BorderRadius.circular(12),
                           ),
                         ),
-                        child: const Text(
-                          '添加',
+                        child: Text(
+                          S.of(context)!.add,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
@@ -1516,8 +1554,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                             borderRadius: BorderRadius.circular(12),
                           ),
                         ),
-                        child: const Text(
-                          '取消',
+                        child: Text(
+                          S.of(context)!.cancel,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w500,
@@ -1561,8 +1599,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          const Text(
-                            '编辑MiniMax配置',
+                          Text(                            S.of(context)!.editMinimaxConfig,
                             style: TextStyle(
                               fontSize: 22,
                               fontWeight: FontWeight.bold,
@@ -1576,9 +1613,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ),
                         ],
                       ),
-                      const SizedBox(height: 24),
-                      const Text(
-                        '配置名称',
+                      SizedBox(height: 24),
+                      Text(                        S.of(context)!.configName,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -1629,9 +1665,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ),
                         ),
                       ),
-                      const SizedBox(height: 16),
-                      const Text(
-                        '模型',
+                      SizedBox(height: 16),
+                      Text(                        S.of(context)!.model,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -1671,7 +1706,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                           ),
                         ),
                       ),
-                      const SizedBox(height: 24),
+                      SizedBox(height: 24),
                       ElevatedButton(
                         onPressed: () async {
                           final name = nameController.text.trim();
@@ -1679,7 +1714,7 @@ class _SettingsScreenState extends State<SettingsScreen>
 
                           if (name.isEmpty || apiKey.isEmpty) {
                             ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('请填写所有字段')),
+                              SnackBar(content: Text(S.of(context)!.fillAllFields)),
                             );
                             return;
                           }
@@ -1699,7 +1734,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                           Navigator.of(context).pop();
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: const Text('已更新MiniMax配置'),
+                              content: Text(S.of(context)!.minimaxConfigUpdated),
                               backgroundColor: Colors.green.shade600,
                               behavior: SnackBarBehavior.floating,
                               shape: RoundedRectangleBorder(
@@ -1718,8 +1753,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                             borderRadius: BorderRadius.circular(12),
                           ),
                         ),
-                        child: const Text(
-                          '保存',
+                        child: Text(
+                          S.of(context)!.save,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
@@ -1737,8 +1772,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                             borderRadius: BorderRadius.circular(12),
                           ),
                         ),
-                        child: const Text(
-                          '取消',
+                        child: Text(
+                          S.of(context)!.cancel,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w500,
@@ -1775,8 +1810,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      const Text(
-                        '删除MiniMax配置',
+                      Text(                        S.of(context)!.deleteMinimaxConfig,
                         style: TextStyle(
                           fontSize: 22,
                           fontWeight: FontWeight.bold,
@@ -1805,10 +1839,10 @@ class _SettingsScreenState extends State<SettingsScreen>
                           color: Colors.red.shade700,
                           size: 24,
                         ),
-                        const SizedBox(width: 12),
+                        SizedBox(width: 12),
                         Expanded(
                           child: Text(
-                            '确定要删除"${config.name}"配置吗？',
+                            '${S.of(context)!.confirmDeleteMinimax}',
                             style: TextStyle(
                               fontSize: 16,
                               color: Colors.red.shade900,
@@ -1837,7 +1871,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       Navigator.of(context).pop();
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: const Text('已删除配置'),
+                          content: Text(S.of(context)!.configDeleted),
                           backgroundColor: Colors.green.shade600,
                           behavior: SnackBarBehavior.floating,
                           shape: RoundedRectangleBorder(
@@ -1847,8 +1881,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       );
                     },
-                    child: const Text(
-                      '删除',
+                    child: Text(
+                      S.of(context)!.delete,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -1866,8 +1900,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                         borderRadius: BorderRadius.circular(12),
                       ),
                     ),
-                    child: const Text(
-                      '取消',
+                    child: Text(
+                      S.of(context)!.cancel,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w500,
@@ -1892,13 +1926,12 @@ class _SettingsScreenState extends State<SettingsScreen>
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _buildCard(
-                title: '小智服务配置',
-                subtitle: '管理小智语音服务配置',
+                title: S.of(context)!.xiaozhiServiceConfig,
+                subtitle: S.of(context)!.xiaozhiServiceConfigSubtitle,
                 actionButton: ElevatedButton.icon(
                   onPressed: _showAddXiaozhiConfigDialog,
                   icon: const Icon(Icons.add, color: Colors.white, size: 18),
-                  label: const Text(
-                    '添加服务',
+                  label: Text(                    S.of(context)!.addService,
                     style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
                   ),
                   style: ElevatedButton.styleFrom(
@@ -1918,9 +1951,9 @@ class _SettingsScreenState extends State<SettingsScreen>
                 child: Column(
                   children: [
                     if (xiaozhiConfigs.isEmpty)
-                      const Padding(
+                      Padding(
                         padding: EdgeInsets.all(16),
-                        child: Center(child: Text('暂无小智服务，点击右上角添加')),
+                        child: Center(child: Text(S.of(context)!.noXiaozhiService)),
                       )
                     else
                       ...xiaozhiConfigs.map(
@@ -2047,20 +2080,20 @@ class _SettingsScreenState extends State<SettingsScreen>
                 ),
               ],
             ),
-            const SizedBox(height: 16),
+            SizedBox(height: 16),
             Row(
               children: [
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Text(
-                        'MAC地址:',
+                      Text(
+                        S.of(context)!.macAddress + ':',
                         style: TextStyle(color: Colors.grey, fontSize: 14),
                       ),
-                      const SizedBox(height: 4),
+                      SizedBox(height: 4),
                       Text(
-                        config.macAddress.isEmpty ? '未设置' : config.macAddress,
+                        config.macAddress.isEmpty ? S.of(context)!.unconfigured : config.macAddress,
                         style: const TextStyle(fontSize: 14),
                       ),
                     ],
@@ -2074,9 +2107,9 @@ class _SettingsScreenState extends State<SettingsScreen>
                         'Token:',
                         style: TextStyle(color: Colors.grey, fontSize: 14),
                       ),
-                      const SizedBox(height: 4),
+                      SizedBox(height: 4),
                       Text(
-                        config.token.isEmpty ? '未设置' : config.token,
+                        config.token.isEmpty ? S.of(context)!.unconfigured : config.token,
                         style: const TextStyle(fontSize: 14),
                       ),
                     ],
@@ -2186,8 +2219,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '添加小智服务',
+                        Text(                          S.of(context)!.addXiaozhiService,
                           style: TextStyle(
                             fontSize: 22,
                             fontWeight: FontWeight.bold,
@@ -2214,14 +2246,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
-                    const Text(
-                      '添加新的小智语音服务配置',
+                    SizedBox(height: 8),
+                    Text(                      S.of(context)!.addNewXiaozhiServiceConfig,
                       style: TextStyle(color: Colors.grey, fontSize: 14),
                     ),
-                    const SizedBox(height: 24),
-                    const Text(
-                      '服务名称',
+                    SizedBox(height: 24),
+                    Text(                      S.of(context)!.serviceName,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -2245,7 +2275,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       child: TextField(
                         controller: nameController,
                         decoration: InputDecoration(
-                          hintText: '例如：家庭小智',
+                          hintText: S.of(context)!.inputServiceName,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -2255,9 +2285,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ),
                     ),
-                    const SizedBox(height: 16),
-                    const Text(
-                      'WebSocket地址',
+                    SizedBox(height: 16),
+                    Text(                      S.of(context)!.websocketAddress,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -2281,7 +2310,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       child: TextField(
                         controller: websocketUrlController,
                         decoration: InputDecoration(
-                          hintText: '例如：wss://example.com',
+                          hintText: S.of(context)!.wsExample,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -2291,12 +2320,11 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ),
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          'MAC地址 (可选)',
+                        Text(                          S.of(context)!.macAddressOptional,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
@@ -2323,7 +2351,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         enabled: true,
                         controller: macAddressController,
                         decoration: InputDecoration(
-                          hintText: '留空将自动生成',
+                          hintText: S.of(context)!.autoGenerate,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -2333,17 +2361,15 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ),
                     ),
-                    const SizedBox(height: 4),
-                    const Text(
-                      '留空将根据设备ID自动生成',
+                    SizedBox(height: 4),
+                    Text(                      S.of(context)!.autoGenerateDesc,
                       style: TextStyle(color: Colors.grey, fontSize: 12),
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          'Token',
+                        Text(                          S.of(context)!.token,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
@@ -2358,8 +2384,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                             color: Colors.grey.shade100,
                             borderRadius: BorderRadius.circular(8),
                           ),
-                          child: const Text(
-                            '默认开启',
+                          child: Text(                            S.of(context)!.enabledByDefault,
                             style: TextStyle(color: Colors.grey, fontSize: 14),
                           ),
                         ),
@@ -2402,7 +2427,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         if (name.isEmpty || websocketUrl.isEmpty) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: const Text('请填写所有必填字段'),
+                              content: Text(S.of(context)!.fillRequiredFields),
                               backgroundColor: Colors.red.shade600,
                               behavior: SnackBarBehavior.floating,
                               shape: RoundedRectangleBorder(
@@ -2427,7 +2452,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         Navigator.pop(context);
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: const Text('小智服务已添加'),
+                            content: Text(S.of(context)!.xiaozhiServiceAdded),
                             backgroundColor: Colors.green.shade600,
                             behavior: SnackBarBehavior.floating,
                             shape: RoundedRectangleBorder(
@@ -2447,8 +2472,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '添加',
+                      child: Text(
+                        S.of(context)!.add,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -2466,8 +2491,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '取消',
+                      child: Text(
+                        S.of(context)!.cancel,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
@@ -2520,8 +2545,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '编辑小智服务',
+                        Text(                          S.of(context)!.editXiaozhiService,
                           style: TextStyle(
                             fontSize: 22,
                             fontWeight: FontWeight.bold,
@@ -2535,14 +2559,12 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
-                    const Text(
-                      '修改小智语音服务配置',
+                    SizedBox(height: 8),
+                    Text(                      S.of(context)!.modifyXiaozhiServiceConfig,
                       style: TextStyle(color: Colors.grey, fontSize: 14),
                     ),
-                    const SizedBox(height: 24),
-                    const Text(
-                      '服务名称',
+                    SizedBox(height: 24),
+                    Text(                      S.of(context)!.serviceName,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -2566,7 +2588,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       child: TextField(
                         controller: nameController,
                         decoration: InputDecoration(
-                          hintText: '例如：家庭小智',
+                          hintText: S.of(context)!.inputServiceName,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -2576,9 +2598,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ),
                     ),
-                    const SizedBox(height: 16),
-                    const Text(
-                      'WebSocket地址',
+                    SizedBox(height: 16),
+                    Text(                      S.of(context)!.websocketAddress,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -2602,7 +2623,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                       child: TextField(
                         controller: websocketUrlController,
                         decoration: InputDecoration(
-                          hintText: '例如：wss://example.com',
+                          hintText: S.of(context)!.wsExample,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -2612,9 +2633,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ),
                     ),
-                    const SizedBox(height: 16),
-                    const Text(
-                      'MAC地址',
+                    SizedBox(height: 16),
+                    Text(                      S.of(context)!.macAddress,
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
@@ -2631,7 +2651,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         controller: macAddressController,
                         enabled: true,
                         decoration: InputDecoration(
-                          hintText: '留空将自动生成',
+                          hintText: S.of(context)!.autoGenerate,
                           hintStyle: TextStyle(color: Colors.grey.shade400),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 16,
@@ -2641,17 +2661,15 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ),
                     ),
-                    const SizedBox(height: 4),
-                    const Text(
-                      '留空将根据设备ID自动生成',
+                    SizedBox(height: 4),
+                    Text(                      S.of(context)!.autoGenerateDesc,
                       style: TextStyle(color: Colors.grey, fontSize: 12),
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          'Token',
+                        Text(                          S.of(context)!.token,
                           style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
@@ -2666,8 +2684,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                             color: Colors.grey.shade100,
                             borderRadius: BorderRadius.circular(8),
                           ),
-                          child: const Text(
-                            '默认开启',
+                          child: Text(                            S.of(context)!.enabledByDefault,
                             style: TextStyle(color: Colors.grey, fontSize: 14),
                           ),
                         ),
@@ -2710,7 +2727,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         if (name.isEmpty || websocketUrl.isEmpty) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: const Text('请填写所有必填字段'),
+                              content: Text(S.of(context)!.fillRequiredFields),
                               backgroundColor: Colors.red.shade600,
                               behavior: SnackBarBehavior.floating,
                               shape: RoundedRectangleBorder(
@@ -2740,7 +2757,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         Navigator.pop(context);
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: const Text('小智服务已更新'),
+                            content: Text(S.of(context)!.xiaozhiServiceUpdated),
                             backgroundColor: Colors.green.shade600,
                             behavior: SnackBarBehavior.floating,
                             shape: RoundedRectangleBorder(
@@ -2760,8 +2777,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '保存',
+                      child: Text(
+                        S.of(context)!.save,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -2779,8 +2796,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '取消',
+                      child: Text(
+                        S.of(context)!.cancel,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
@@ -2825,8 +2842,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '删除小智服务',
+                        Text(                          S.of(context)!.deleteXiaozhiService,
                           style: TextStyle(
                             fontSize: 22,
                             fontWeight: FontWeight.bold,
@@ -2840,9 +2856,9 @@ class _SettingsScreenState extends State<SettingsScreen>
                         ),
                       ],
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
                     Text(
-                      '确定要删除 ${config.name} 吗？',
+                      '${S.of(context)!.confirmDeleteXiaozhi}',
                       style: const TextStyle(fontSize: 16),
                     ),
                     const SizedBox(height: 24),
@@ -2856,7 +2872,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                         Navigator.pop(context);
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            content: const Text('小智服务已删除'),
+                            content: Text(S.of(context)!.xiaozhiServiceDeleted),
                             backgroundColor: Colors.green.shade600,
                             behavior: SnackBarBehavior.floating,
                             shape: RoundedRectangleBorder(
@@ -2876,8 +2892,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '删除',
+                      child: Text(
+                        S.of(context)!.delete,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -2895,8 +2911,8 @@ class _SettingsScreenState extends State<SettingsScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: const Text(
-                        '取消',
+                      child: Text(
+                        S.of(context)!.cancel,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,

--- a/lib/services/minimax_service.dart
+++ b/lib/services/minimax_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'dart:async';
-import 'dart:math' as math;
+import 'dart:io';
 import 'package:http/http.dart' as http;
 
 /// MiniMax AI service using OpenAI-compatible Chat Completions API.
@@ -16,10 +16,10 @@ class MiniMaxService {
   // Store conversation history per session for multi-turn support
   final Map<String, List<Map<String, String>>> _sessionHistory = {};
 
-  MiniMaxService({
-    required this.apiKey,
-    required this.model,
-  });
+  MiniMaxService({required this.apiKey, required this.model});
+
+  static const String _networkErrorMessage =
+      '无法连接到 MiniMax 服务，请检查网络连接或 macOS App 网络权限后重试。';
 
   /// Send a message and get a blocking response.
   Future<String> sendMessage(
@@ -42,9 +42,6 @@ class MiniMaxService {
       final requestUrl = '$_baseUrl/chat/completions';
 
       print('MiniMaxService: 发送请求到 $requestUrl');
-      print(
-        'MiniMaxService: API Key = ${apiKey.substring(0, math.min(5, apiKey.length))}...',
-      );
       print('MiniMaxService: 模型 = $model');
       print('MiniMaxService: 会话 ID = $sessionId');
 
@@ -88,6 +85,12 @@ class MiniMaxService {
           'API 请求失败: ${response.statusCode}, 响应: ${response.body}',
         );
       }
+    } on SocketException catch (e) {
+      print('MiniMaxService 网络错误: $e');
+      throw MiniMaxNetworkException(_networkErrorMessage);
+    } on http.ClientException catch (e) {
+      print('MiniMaxService 客户端错误: $e');
+      throw MiniMaxNetworkException(_networkErrorMessage);
     } catch (e) {
       print('MiniMaxService 错误: $e');
       throw Exception('发送消息失败: $e');
@@ -115,9 +118,6 @@ class MiniMaxService {
       final requestUrl = '$_baseUrl/chat/completions';
 
       print('MiniMaxService Stream: 发送请求到 $requestUrl');
-      print(
-        'MiniMaxService Stream: API Key = ${apiKey.substring(0, math.min(5, apiKey.length))}...',
-      );
       print('MiniMaxService Stream: 模型 = $model');
       print('MiniMaxService Stream: 会话 ID = $sessionId');
 
@@ -138,9 +138,7 @@ class MiniMaxService {
       request.body = requestBody;
 
       final streamedResponse = await http.Client().send(request);
-      print(
-        'MiniMaxService Stream: 响应状态码 = ${streamedResponse.statusCode}',
-      );
+      print('MiniMaxService Stream: 响应状态码 = ${streamedResponse.statusCode}');
 
       if (streamedResponse.statusCode != 200) {
         final responseBody = await streamedResponse.stream.bytesToString();
@@ -186,6 +184,12 @@ class MiniMaxService {
       // Strip thinking tags from full content and add to history
       final cleanContent = _stripThinkingTags(fullContent.toString());
       history.add({'role': 'assistant', 'content': cleanContent});
+    } on SocketException catch (e) {
+      print('MiniMaxService Stream 网络错误: $e');
+      yield '【$_networkErrorMessage】';
+    } on http.ClientException catch (e) {
+      print('MiniMaxService Stream 客户端错误: $e');
+      yield '【$_networkErrorMessage】';
     } catch (e) {
       print('MiniMaxService Stream 错误: $e');
       yield '【服务响应异常】';
@@ -208,4 +212,13 @@ class MiniMaxService {
   String _stripThinkingTags(String content) {
     return content.replaceAll(RegExp(r'<think>[\s\S]*?</think>'), '').trim();
   }
+}
+
+class MiniMaxNetworkException implements Exception {
+  final String message;
+
+  const MiniMaxNetworkException(this.message);
+
+  @override
+  String toString() => message;
 }

--- a/lib/widgets/conversation_tile.dart
+++ b/lib/widgets/conversation_tile.dart
@@ -5,6 +5,7 @@ import 'package:ai_assistant/models/conversation.dart';
 import 'package:ai_assistant/models/xiaozhi_config.dart';
 import 'package:ai_assistant/models/dify_config.dart';
 import 'package:ai_assistant/providers/config_provider.dart';
+import 'package:ai_assistant/l10n/app_localizations.dart';
 
 class ConversationTile extends StatelessWidget {
   final Conversation conversation;
@@ -70,7 +71,7 @@ class ConversationTile extends StatelessWidget {
                             ),
                           ),
                           Text(
-                            _formatTime(conversation.lastMessageTime),
+                            _formatTime(context, conversation.lastMessageTime),
                             style: TextStyle(
                               fontSize: 14,
                               color: Colors.grey.shade500,
@@ -109,7 +110,7 @@ class ConversationTile extends StatelessWidget {
 
   Widget _buildTypeTag(BuildContext context) {
     final bool isDify = conversation.type == ConversationType.dify;
-    String label = isDify ? '文本' : '语音';
+    String label = isDify ? S.of(context)!.text : S.of(context)!.voice;
 
     // 如果有配置ID且不为空，则显示配置名称
     if (conversation.configId.isNotEmpty) {
@@ -175,14 +176,14 @@ class ConversationTile extends StatelessWidget {
     }
   }
 
-  String _formatTime(DateTime dateTime) {
+  String _formatTime(BuildContext context, DateTime dateTime) {
     final now = DateTime.now();
     final difference = now.difference(dateTime);
 
     if (difference.inDays > 0 && difference.inDays <= 1) {
-      return '昨天';
+      return S.of(context)!.yesterday;
     } else if (difference.inDays > 1 && difference.inDays <= 7) {
-      return '周${_getWeekday(dateTime.weekday)}';
+      return '周${_getWeekday(context, dateTime.weekday)}';
     } else {
       // 当天显示时间
       final hour = dateTime.hour.toString().padLeft(2, '0');
@@ -191,24 +192,26 @@ class ConversationTile extends StatelessWidget {
     }
   }
 
-  String _getWeekday(int weekday) {
+
+  String _getWeekday(BuildContext context, int weekday) {
     switch (weekday) {
       case 1:
-        return '一';
+        return S.of(context)!.weekday1;
       case 2:
-        return '二';
+        return S.of(context)!.weekday2;
       case 3:
-        return '三';
+        return S.of(context)!.weekday3;
       case 4:
-        return '四';
+        return S.of(context)!.weekday4;
       case 5:
-        return '五';
+        return S.of(context)!.weekday5;
       case 6:
-        return '六';
+        return S.of(context)!.weekday6;
       case 7:
-        return '日';
+        return S.of(context)!.weekday7;
       default:
         return '';
     }
   }
+
 }

--- a/lib/widgets/discovery_screen.dart
+++ b/lib/widgets/discovery_screen.dart
@@ -1,3 +1,4 @@
+import 'package:ai_assistant/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 
 class DiscoveryScreen extends StatelessWidget {
@@ -5,12 +6,13 @@ class DiscoveryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final s = S.of(context)!;
     return Column(
       children: [
         AppBar(
-          title: const Text(
-            '发现',
-            style: TextStyle(
+          title: Text(
+            s.discover,
+            style: const TextStyle(
               fontWeight: FontWeight.bold,
               fontSize: 28,
               color: Colors.black,
@@ -29,11 +31,11 @@ class DiscoveryScreen extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Padding(
-                  padding: EdgeInsets.fromLTRB(20, 16, 20, 16),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
                   child: Text(
-                    '实用工具',
-                    style: TextStyle(
+                    s.practicalTools,
+                    style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
                       color: Colors.black87,
@@ -43,11 +45,11 @@ class DiscoveryScreen extends StatelessWidget {
                 _buildFeaturesGrid(context),
                 const SizedBox(height: 24),
 
-                const Padding(
-                  padding: EdgeInsets.fromLTRB(20, 16, 20, 16),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
                   child: Text(
-                    '精选推荐',
-                    style: TextStyle(
+                    s.featuredRecommendations,
+                    style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
                       color: Colors.black87,
@@ -55,7 +57,6 @@ class DiscoveryScreen extends StatelessWidget {
                   ),
                 ),
                 _buildRecommendations(context),
-                // 添加底部间距，避免内容被底部导航栏遮挡
                 SizedBox(height: MediaQuery.of(context).padding.bottom + 80),
               ],
             ),
@@ -66,6 +67,7 @@ class DiscoveryScreen extends StatelessWidget {
   }
 
   Widget _buildFeaturesGrid(BuildContext context) {
+    final s = S.of(context)!;
     return GridView.count(
       crossAxisCount: 2,
       shrinkWrap: true,
@@ -77,60 +79,60 @@ class DiscoveryScreen extends StatelessWidget {
       children: [
         _buildFeatureCard(
           context,
-          '阅读助手',
-          '高效理解和总结文章',
+          s.readingAssistant,
+          s.readingAssistantDesc,
           Icons.menu_book_outlined,
           const Color(0xFFFF6D00),
           onTap: () {
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('阅读助手功能开发中...'),
-                duration: Duration(seconds: 2),
+              SnackBar(
+                content: Text('${s.readingAssistant}${s.underDevelopment}'),
+                duration: const Duration(seconds: 2),
               ),
             );
           },
         ),
         _buildFeatureCard(
           context,
-          '翻译工具',
-          '多语言实时翻译',
+          s.translationTool,
+          s.translationToolDesc,
           Icons.translate_outlined,
           const Color(0xFF2979FF),
           onTap: () {
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('翻译工具功能开发中...'),
-                duration: Duration(seconds: 2),
+              SnackBar(
+                content: Text('${s.translationTool}${s.underDevelopment}'),
+                duration: const Duration(seconds: 2),
               ),
             );
           },
         ),
         _buildFeatureCard(
           context,
-          '语音助手',
-          '智能语音交互',
+          s.voiceAssistant,
+          s.voiceAssistantDesc,
           Icons.mic_outlined,
           const Color(0xFF6200EA),
           onTap: () {
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('语音助手功能开发中...'),
-                duration: Duration(seconds: 2),
+              SnackBar(
+                content: Text('${s.voiceAssistant}${s.underDevelopment}'),
+                duration: const Duration(seconds: 2),
               ),
             );
           },
         ),
         _buildFeatureCard(
           context,
-          '文档解析',
-          '智能分析文档内容',
+          s.documentParser,
+          s.documentParserDesc,
           Icons.description_outlined,
           const Color(0xFF00BFA5),
           onTap: () {
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('文档解析功能开发中...'),
-                duration: Duration(seconds: 2),
+              SnackBar(
+                content: Text('${s.documentParser}${s.underDevelopment}'),
+                duration: const Duration(seconds: 2),
               ),
             );
           },
@@ -210,6 +212,7 @@ class DiscoveryScreen extends StatelessWidget {
   }
 
   Widget _buildRecommendations(BuildContext context) {
+    final s = S.of(context)!;
     return SizedBox(
       height: 180,
       child: ListView(
@@ -219,22 +222,22 @@ class DiscoveryScreen extends StatelessWidget {
         children: [
           _buildRecommendationCard(
             context,
-            'AI写作助手',
-            '让你的文章更专业',
+            s.aiWritingAssistant,
+            s.aiWritingAssistantDesc,
             'assets/images/writing.png',
             const Color(0xFFE91E63),
           ),
           _buildRecommendationCard(
             context,
-            '智能提醒',
-            '不错过重要事项',
+            s.smartReminder,
+            s.smartReminderDesc,
             'assets/images/reminder.png',
             const Color(0xFF4CAF50),
           ),
           _buildRecommendationCard(
             context,
-            '语音笔记',
-            '随时随地记录灵感',
+            s.voiceNotes,
+            s.voiceNotesDesc,
             'assets/images/voice_note.png',
             const Color(0xFF3F51B5),
           ),
@@ -250,6 +253,7 @@ class DiscoveryScreen extends StatelessWidget {
     String imagePath,
     Color color,
   ) {
+    final s = S.of(context)!;
     return Container(
       width: 200,
       margin: const EdgeInsets.only(right: 16),
@@ -273,7 +277,7 @@ class DiscoveryScreen extends StatelessWidget {
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: Text('$title 功能开发中...'),
+                  content: Text('$title ${s.underDevelopment}'),
                   duration: const Duration(seconds: 2),
                 ),
               );

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -5,6 +5,9 @@ PODS:
     - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
+  - flutter_blue_plus_darwin (0.0.2):
+    - Flutter
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - just_audio (0.0.1):
     - Flutter
@@ -22,6 +25,7 @@ DEPENDENCIES:
   - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
+  - flutter_blue_plus_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_blue_plus_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - just_audio (from `Flutter/ephemeral/.symlinks/plugins/just_audio/darwin`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
@@ -35,6 +39,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
+  flutter_blue_plus_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_blue_plus_darwin/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
   just_audio:
@@ -50,7 +56,8 @@ SPEC CHECKSUMS:
   audio_session: eaca2512cf2b39212d724f35d11f46180ad3a33e
   device_info_plus: a56e6e74dbbd2bb92f2da12c64ddd4f67a749041
   file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  flutter_blue_plus_darwin: 09444a26fb6bdef523e55b68fc1c59af5a877ea6
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   record_darwin: 30509266ae213af8afdb09a8ae7467cb64c1377e

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		37A75DDD26744361BF11F70E /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F5F49D199BE8B2E5047CE8B /* Pods_RunnerTests.framework */; };
+		C7E2734126A1FBF387972F43 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ECC6F49C8567ED8224E9BB5 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1C61B0B5F077B1554929CF92 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		226885787069F905C4C57CF8 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* ai_assistant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ai_assistant.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* ai_assistant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ai_assistant.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +80,14 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		3F5F49D199BE8B2E5047CE8B /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		67A38FBB5E6AC680C0480F44 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		6CFA0D423302FC5083BDEE49 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8ECC6F49C8567ED8224E9BB5 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		C588E482F042EE384100C91A /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		E2B367A3F1F84DD3CA83BE8F /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				37A75DDD26744361BF11F70E /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C7E2734126A1FBF387972F43 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				5DAFD093254D1F776D574368 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,9 +185,25 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		5DAFD093254D1F776D574368 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1C61B0B5F077B1554929CF92 /* Pods-Runner.debug.xcconfig */,
+				67A38FBB5E6AC680C0480F44 /* Pods-Runner.release.xcconfig */,
+				E2B367A3F1F84DD3CA83BE8F /* Pods-Runner.profile.xcconfig */,
+				6CFA0D423302FC5083BDEE49 /* Pods-RunnerTests.debug.xcconfig */,
+				C588E482F042EE384100C91A /* Pods-RunnerTests.release.xcconfig */,
+				226885787069F905C4C57CF8 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8ECC6F49C8567ED8224E9BB5 /* Pods_Runner.framework */,
+				3F5F49D199BE8B2E5047CE8B /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				DC6163A86D4D977D3E2E356B /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				F8002ED459A9740EF2D92B18 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				596706AE1BA5BA73FCCB0844 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -329,6 +361,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		596706AE1BA5BA73FCCB0844 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DC6163A86D4D977D3E2E356B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F8002ED459A9740EF2D92B18 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6CFA0D423302FC5083BDEE49 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C588E482F042EE384100C91A /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 226885787069F905C4C57CF8 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -461,7 +557,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -543,7 +639,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -593,7 +689,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -516,26 +516,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -556,26 +556,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -977,10 +977,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   timeago:
     dependency: "direct main"
     description:
@@ -1009,10 +1009,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1086,5 +1086,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -302,6 +302,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_pcm_player:
     dependency: "direct main"
     description:
@@ -468,10 +473,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   js:
     dependency: transitive
     description:
@@ -985,10 +990,10 @@ packages:
     dependency: "direct main"
     description:
       name: timeago
-      sha256: "054cedf68706bb142839ba0ae6b135f6b68039f0b8301cbe8784ae653d5ff8de"
+      sha256: b05159406a97e1cbb2b9ee4faa9fb096fe0e2dfcd8b08fcd2a00553450d3422e
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.7.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -43,7 +45,7 @@ dependencies:
   http: ^1.2.0
   http_parser: ^4.0.2
   web_socket_channel: ^2.4.0
-  intl: ^0.19.0
+  intl: ^0.20.2
   image_picker: ^1.0.7
   fl_chart: ^0.66.2
   
@@ -107,6 +109,7 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  generate: true
 
   # To add assets to your application, add an assets section, like this:
   # assets:

--- a/test/localization_test.dart
+++ b/test/localization_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ai_assistant/l10n/app_localizations.dart';
+import 'package:ai_assistant/providers/locale_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
+import 'dart:io';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ARB files', () {
+    test('have same keys across all locales', () async {
+      final zhKeys = _loadArbKeys('lib/l10n/app_zh.arb');
+      final enKeys = _loadArbKeys('lib/l10n/app_en.arb');
+      final ruKeys = _loadArbKeys('lib/l10n/app_ru.arb');
+      
+      expect(enKeys, equals(zhKeys), reason: 'English ARB missing keys present in Chinese');
+      expect(ruKeys, equals(zhKeys), reason: 'Russian ARB missing keys present in Chinese');
+    });
+  });
+
+  test('flutter gen-l10n succeeds', () async {
+    final result = await Process.run('flutter', ['gen-l10n']);
+    expect(result.exitCode, 0, reason: 'flutter gen-l10n failed: ${result.stderr}');
+  });
+
+  group('LocaleProvider', () {
+    test('setLocale persists to SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({});
+      final provider = LocaleProvider();
+      await provider.setLocale(const Locale('en'));
+      expect(provider.locale.languageCode, 'en');
+      
+      // Create new provider WITHOUT resetting mock - it should load the persisted value
+      final newProvider = LocaleProvider();
+      await newProvider.loadLocale();
+      expect(newProvider.locale.languageCode, 'en');
+    });
+
+    test('loads saved locale', () async {
+      // Start fresh with the saved locale
+      SharedPreferences.setMockInitialValues({'app_locale': 'ru'});
+      final provider = LocaleProvider();
+      await provider.loadLocale();
+      expect(provider.locale.languageCode, 'ru');
+    });
+  });
+
+  test('Supported locales are en, zh, ru', () {
+    expect(S.supportedLocales.map((l) => l.languageCode), containsAll(['en', 'zh', 'ru']));
+    expect(S.supportedLocales.length, 3);
+  });
+}
+
+Set<String> _loadArbKeys(String path) {
+  final file = File(path);
+  final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  return json.keys.where((k) => !k.startsWith('@')).toSet();
+}


### PR DESCRIPTION
## Summary
- Add i18n support with English, Chinese, and Russian localization
- Implement LocaleProvider for runtime language switching  
- Add ARB localization files and flutter_localizations dependency
- Update all UI screens to use localized strings

## Changes
- `lib/main.dart` - Add localization setup, LocaleProvider integration
- `lib/screens/*.dart` - Replace hardcoded strings with localized versions
- `lib/providers/locale_provider.dart` - New provider for language state
- `lib/l10n/` - ARB files for en/zh/ru
- `pubspec.yaml` - Add flutter_localizations, update intl version
- `l10n.yaml` - Flutter localization config

## After Merge
```bash
flutter pub get
flutter gen-l10n
```